### PR TITLE
Always build glowwindow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,10 +163,7 @@ endif()
 find_package(OpenGL REQUIRED)
 find_package(GLM REQUIRED)
 find_package(GLEW REQUIRED)
-
-if(OPTION_BUILD_EXAMPLES)
-    find_package(GLFW REQUIRED glfw3)
-endif()
+find_package(GLFW REQUIRED glfw3)
 
 # Include directories
 include_directories(
@@ -174,7 +171,9 @@ include_directories(
     ${GLOW_SOURCE_DIR}/include
     ${OPENGL_INCLUDE_DIR}
     ${GLM_INCLUDE_DIR}
-    ${GLEW_INCLUDE_DIR})
+    ${GLEW_INCLUDE_DIR}
+    ${GLFW_INCLUDE_DIR}
+)
 
 # LIBRARIES
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,6 +1,3 @@
 add_subdirectory(glow)
 add_subdirectory(glowutils)
-
-if(OPTION_BUILD_EXAMPLES)
-	add_subdirectory(glowwindow)
-endif()
+add_subdirectory(glowwindow)

--- a/source/glowwindow/CMakeLists.txt
+++ b/source/glowwindow/CMakeLists.txt
@@ -3,9 +3,6 @@
 set(target glowwindow)
 message(STATUS "lib ${target}")
 
-include_directories(
-    ${GLFW_INCLUDE_DIR})
-
 # Libraries
 set(libs
     ${OPENGL_LIBRARIES}
@@ -28,8 +25,6 @@ endif()
 # Sources
 set(header_path "${GLOW_SOURCE_DIR}/include/glowwindow")
 set(source_path "${CMAKE_CURRENT_SOURCE_DIR}")
-
-find_package(GLFW REQUIRED)
 
 set(api_includes
     ${header_path}/Context.h


### PR DESCRIPTION
Since glowwindow is used by other projects, it should be always build with the other two libraries (or at least shouldn't depend on building the examples anymore).
