### PR TITLE
Fix debug output entry signature for current version of glew

### DIFF
--- a/source/glow/debugmessageoutput.cpp
+++ b/source/glow/debugmessageoutput.cpp
@@ -50,7 +50,7 @@ void registerDebugMessageCallback(DebugMessageCallback * messageCallback)
     {
         if (!messageCallback->isRegistered())
         {
-            glDebugMessageCallback(debugMessageCallback, reinterpret_cast<void*>(messageCallback));
+            glDebugMessageCallback(reinterpret_cast<GLDEBUGPROC>(debugMessageCallback), reinterpret_cast<const void*>(messageCallback));
             messageCallback->setRegistered(true);
         }
     }


### PR DESCRIPTION
Maybe the needed change is due to a change in glew, this should be evaluated.
