### PR TITLE
Fixes windows bugs

### DIFF
--- a/source/glow/include/glow/StateSetting.hpp
+++ b/source/glow/include/glow/StateSetting.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <glowbase/FunctionCall.h>
 #include <glow/StateSetting.h>
 
 namespace glow

--- a/source/glow/include/glow/objectlogging.h
+++ b/source/glow/include/glow/objectlogging.h
@@ -41,6 +41,8 @@ GLOW_API LogMessageBuilder operator<<(LogMessageBuilder builder, const AbstractU
 
 template <typename T>
 LogMessageBuilder operator<<(LogMessageBuilder builder, const Uniform<T> * uniform);
+template <typename T>
+LogMessageBuilder operator<<(LogMessageBuilder builder, Uniform<T> * uniform);
 
 } // namespace glow
 

--- a/source/glow/include/glow/objectlogging.hpp
+++ b/source/glow/include/glow/objectlogging.hpp
@@ -20,4 +20,10 @@ LogMessageBuilder operator<<(LogMessageBuilder builder, const Uniform<T> * unifo
     return builder;
 }
 
+template <typename T>
+LogMessageBuilder operator<<(LogMessageBuilder builder, Uniform<T> * uniform)
+{
+	return operator<<(builder, const_cast<const Uniform<T>*>(uniform));
+}
+
 } // namespace glow

--- a/source/glowbase/CMakeLists.txt
+++ b/source/glowbase/CMakeLists.txt
@@ -44,6 +44,7 @@ set(include_path "${CMAKE_CURRENT_SOURCE_DIR}/include/${target}")
 set(source_path "${CMAKE_CURRENT_SOURCE_DIR}/source")
 
 set(sources
+	${source_path}/AbstractFunctionCall.cpp
 	${source_path}/baselogging.cpp
 	${source_path}/Changeable.cpp
 	${source_path}/ChangeListener.cpp
@@ -57,6 +58,7 @@ set(sources
 )
 
 set(api_includes
+	${include_path}/AbstractFunctionCall.h
 	${include_path}/AbstractLogHandler.h
 	${include_path}/baselogging.h
 	${include_path}/baselogging.hpp

--- a/source/glowbase/include/glowbase/AbstractFunctionCall.h
+++ b/source/glowbase/include/glowbase/AbstractFunctionCall.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <glowbase/glowbase_api.h>
+
+namespace glow
+{
+
+class GLOWBASE_API AbstractFunctionCall
+{
+public:
+	AbstractFunctionCall();
+	virtual ~AbstractFunctionCall();
+
+	virtual void operator()() = 0;
+	virtual void * identifier() const = 0;
+
+};
+
+} // namespace glowbase

--- a/source/glowbase/include/glowbase/FunctionCall.h
+++ b/source/glowbase/include/glowbase/FunctionCall.h
@@ -4,19 +4,10 @@
 #include <tuple>
 
 #include <glowbase/glowbase_api.h>
+#include <glowbase/AbstractFunctionCall.h>
 
 namespace glow
 {
-
-class GLOWBASE_API AbstractFunctionCall
-{
-public:
-    virtual void operator()() = 0;
-    virtual void * identifier() const = 0;
-
-    virtual ~AbstractFunctionCall() {}
-};
-
 
 template <typename... Arguments>
 class FunctionCall : public AbstractFunctionCall
@@ -29,6 +20,7 @@ public:
 
     virtual void operator()() override;
     virtual void * identifier() const override;
+
 protected:
     mutable FunctionPointer m_functionPointer;
     std::function<void(Arguments...)> m_function;

--- a/source/glowbase/source/AbstractFunctionCall.cpp
+++ b/source/glowbase/source/AbstractFunctionCall.cpp
@@ -1,0 +1,14 @@
+#include <glowbase/AbstractFunctionCall.h>
+
+namespace glow
+{
+
+AbstractFunctionCall::AbstractFunctionCall() 
+{
+}
+
+AbstractFunctionCall::~AbstractFunctionCall()
+{
+}
+
+} // namespace glowbase


### PR DESCRIPTION
- dllimport functions may NOT be defined in headers
- msvc thinks const is SUPER important
