### PR TITLE
Wrong comment creation for GL_ARB_shading_language_include

### DIFF
--- a/source/globjects/source/IncludeProcessor.cpp
+++ b/source/globjects/source/IncludeProcessor.cpp
@@ -105,7 +105,7 @@ CompositeStringSource* IncludeProcessor::process(const AbstractStringSource* sou
                         // #extension GL_ARB_shading_language_include : require
                         if (contains(trimmedLine, "GL_ARB_shading_language_include"))
                         {
-                            destinationstream << "/*" << trimmedLine.substr(trimmedLine.find("GL_ARB_shading_language_include"), std::string("GL_ARB_shading_language_include").size()) << "*/" << trimmedLine.substr(trimmedLine.find("GL_ARB_shading_language_include") + std::string("GL_ARB_shading_language_include").size()) << '\n';
+                            destinationstream << "/*" << trimmedLine << "*/\n";
                         }
                         else
                         {


### PR DESCRIPTION
When the include processor finds the line
# extension GL_ARB_shading_language_include : require

it's replaced with
/\* GL_ARB_shading_language_include */ : require

instead of (for example)
/\* #extension GL_ARB_shading_language_include : require */

causing the shader compiler to find an unexpected ":" and thus fail to compile the shader
