### PR TITLE
Disable examples by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ project(${META_PROJECT_NAME} C CXX)
 option(OPTION_PORTABLE_INSTALL    "Install to a local directory instead of the system" OFF)
 option(OPTION_BUILD_STATIC        "Build static libraries" OFF)
 option(OPTION_BUILD_TESTS         "Build tests (if gmock and gtest are found)" ON)
-option(OPTION_BUILD_EXAMPLES      "Build examples (requires GLFW)" ON)
+option(OPTION_BUILD_EXAMPLES      "Build examples (requires GLFW)" OFF)
 option(OPTION_ERRORS_AS_EXCEPTION "Throw exceptions" OFF)
 
 


### PR DESCRIPTION
Disable building examples by default since:
- They require GLFW, at least for me it's confusing to be presented with this requirement by cmake if I just want to build the library (and that's the most common use case of globjects, I think. Few people care about examples).
- At least one example (WorldInHandNavigation, iirc, including glm/gtx/constants.hpp) uses a header from glm  0.9.4, but the official requirement of globjects is glm >= 0.9.5
