### PR TITLE
Bring make_ref() semantics on par with std::make_shared()

### DIFF
--- a/source/globjects/include/globjects/base/ref_ptr.h
+++ b/source/globjects/include/globjects/base/ref_ptr.h
@@ -66,8 +66,8 @@ protected:
     mutable const Referenced * m_referenced;
 };
 
-template <typename T>
-ref_ptr<T> make_ref(T * object);
+template<typename T, typename... Args>
+ref_ptr<T> make_ref(Args&&... args);
 
 } // namespace globjects
 

--- a/source/globjects/include/globjects/base/ref_ptr.hpp
+++ b/source/globjects/include/globjects/base/ref_ptr.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <utility>
+
 #include <globjects/base/ref_ptr.h>
 
 #include <globjects/base/Referenced.h>
 
 
-namespace globjects 
+namespace globjects
 {
 
 template<typename T>
@@ -143,10 +145,10 @@ void ref_ptr<T>::decreaseRef()
 		m_referenced->unref();
 }
 
-template <typename T>
-ref_ptr<T> make_ref(T * object)
+template<typename T, typename... Args>
+ref_ptr<T> make_ref(Args&&... args)
 {
-    return ref_ptr<T>(object);
+    return new T(std::forward<Args>(args)...);
 }
 
 } // namespace globjects

--- a/source/tests/globjects-test/CMakeLists.txt
+++ b/source/tests/globjects-test/CMakeLists.txt
@@ -32,6 +32,7 @@ set(libs
 set(sources
     main.cpp
     ref_ptr_test.cpp
+    make_ref_test.cpp
     Referenced_test.cpp
 )
 

--- a/source/tests/globjects-test/make_ref_test.cpp
+++ b/source/tests/globjects-test/make_ref_test.cpp
@@ -1,0 +1,70 @@
+
+#include <gmock/gmock.h>
+
+
+#include <globjects/base/ref_ptr.h>
+
+class make_ref_test : public testing::Test
+{
+public:
+};
+
+namespace
+{
+class ReferencedMock : public globjects::Referenced
+{
+public:
+    int m_i;
+    float m_j;
+
+    ReferencedMock(int i, float j):
+        m_i(i),
+        m_j(j)
+    {     
+    }
+
+    ReferencedMock(float && j, int && i):
+        m_i(i),
+        m_j(j)
+    {     
+    }
+
+    ReferencedMock():
+        m_i(13),
+        m_j(3.7f)
+    {     
+    }
+};
+}
+
+TEST_F(make_ref_test, CallableByValue)
+{
+    globjects::ref_ptr<ReferencedMock> ref = globjects::make_ref<ReferencedMock>(5, 3.0f);
+
+    EXPECT_EQ(ref->m_i, 5);
+    EXPECT_FLOAT_EQ(ref->m_j, 3.0f);
+}
+
+TEST_F(make_ref_test, CallableByRValue)
+{
+    globjects::ref_ptr<ReferencedMock> ref = globjects::make_ref<ReferencedMock>(2.3f, 6);
+
+    EXPECT_EQ(ref->m_i, 6);
+    EXPECT_FLOAT_EQ(ref->m_j, 2.3f);
+}
+
+TEST_F(make_ref_test, CallableWithoutParams)
+{
+    globjects::ref_ptr<ReferencedMock> ref = globjects::make_ref<ReferencedMock>();
+
+    EXPECT_EQ(ref->m_i, 13);
+    EXPECT_FLOAT_EQ(ref->m_j, 3.7f);
+}
+
+TEST_F(make_ref_test, CorrectRefCount)
+{
+    globjects::ref_ptr<ReferencedMock> ref = globjects::make_ref<ReferencedMock>();
+
+    EXPECT_EQ(ref->refCounter(), 1);
+}
+


### PR DESCRIPTION
This changes the semantics of globjects::make_ref() from being a wrapper around a call to a constructor of globjects::ref_ptr() to those of std::make_shared() (and std::make_unique()) thus enabling "new-free" programming with globjects. Herb Sutter would approve this.

I also added a little test for the function.
