### PR TITLE
TransformFeedback::setVaryings(): Take std::string instead of const char*

### DIFF
--- a/source/globjects/include/globjects/TransformFeedback.h
+++ b/source/globjects/include/globjects/TransformFeedback.h
@@ -71,10 +71,11 @@ public:
     void draw(gl::GLenum primitiveMode) const;
 
     void setVaryings(const Program * program, gl::GLsizei count, const char ** varyingNames, gl::GLenum bufferMode);
-    void setVaryings(const Program * program, const std::vector<const char *> & varyingNames, gl::GLenum bufferMode);
+
+    void setVaryings(const Program * program, const std::vector<std::string> & varyingNames, gl::GLenum bufferMode);
 
     template <std::size_t Count>
-    void setVaryings(const Program * program, const std::array<const char *, Count> & varyingNames, gl::GLenum bufferMode);
+    void setVaryings(const Program * program, const std::array<std::string, Count> & varyingNames, gl::GLenum bufferMode);
 
     static bool isTransformFeedback(gl::GLuint id);
 

--- a/source/globjects/include/globjects/TransformFeedback.hpp
+++ b/source/globjects/include/globjects/TransformFeedback.hpp
@@ -5,9 +5,17 @@
 namespace globjects {
 
 template <std::size_t Count>
-void TransformFeedback::setVaryings(const Program * program, const std::array<const char *, Count> &varyingNames, gl::GLenum bufferMode)
+void TransformFeedback::setVaryings(const Program * program, const std::array<std::string, Count> & varyingNames, gl::GLenum bufferMode)
 {
-    setVaryings(program, static_cast<gl::GLint>(Count), const_cast<const char**>(varyingNames.data()), bufferMode);
+    std::vector<const char*> c_ptrs;
+    c_ptrs.reserve(varyingNames.size());
+
+    for (auto & name : varyingNames)
+    {
+        c_ptrs.push_back(name.c_str());
+    }
+
+    setVaryings(program, static_cast<gl::GLint>(Count), const_cast<const char**>(c_ptrs.data()), bufferMode);
 }
 
 } // namespace globjects

--- a/source/globjects/source/TransformFeedback.cpp
+++ b/source/globjects/source/TransformFeedback.cpp
@@ -89,9 +89,17 @@ void TransformFeedback::setVaryings(const Program * program, const GLsizei count
 	program->invalidate();
 }
 
-void TransformFeedback::setVaryings(const Program *program, const std::vector<const char*> & varyingNames, const GLenum bufferMode)
+void TransformFeedback::setVaryings(const Program * program, const std::vector<std::string> & varyingNames, GLenum bufferMode)
 {
-    setVaryings(program, static_cast<GLint>(varyingNames.size()), const_cast<const char**>(varyingNames.data()), bufferMode);
+    std::vector<const char*> c_ptrs;
+    c_ptrs.reserve((varyingNames.size()));
+
+    for (auto & name : varyingNames)
+    {
+        c_ptrs.push_back(name.data());
+    }
+
+    setVaryings(program, static_cast<GLint>(varyingNames.size()), const_cast<const char**>(c_ptrs.data()), bufferMode);
 }
 
 bool TransformFeedback::isTransformFeedback(const GLuint id)


### PR DESCRIPTION
For the two convenience methods taking `std::array` and `std::vector` as parameters, change the template type from `const char*` to `std::string`. Note that, e.g., `{"o_position", "o_color"}` can still be used as a parameter. Programs that are not hard-coding the names of their transform feedback varyings benefit from this change.
