### PR TITLE
Add class TextureHandle

### DIFF
--- a/source/examples/bindless-textures/main.cpp
+++ b/source/examples/bindless-textures/main.cpp
@@ -157,8 +157,10 @@ public:
             Shader::fromFile(GL_FRAGMENT_SHADER, "data/bindless-textures/shader.frag"));
 
         std::array<TextureHandle, std::tuple_size<decltype(m_textures)>::value> handles;
-        for (unsigned i = 0; i < m_textures.size(); ++i)
-            handles[i] = m_textures[i]->makeResident();
+        for (unsigned i = 0; i < m_textures.size(); ++i) {
+            handles[i] = m_textures[i]->textureHandle();
+            handles[i].makeResident();
+        }
 
         m_program->setUniform("textures", handles);
 

--- a/source/globjects/CMakeLists.txt
+++ b/source/globjects/CMakeLists.txt
@@ -184,6 +184,7 @@ set(sources
 	${source_path}/Sync.cpp
 	${source_path}/AttachedTexture.cpp
 	${source_path}/Texture.cpp
+	${source_path}/TextureHandle.cpp
 	${source_path}/TransformFeedback.cpp
 	${source_path}/UniformBlock.cpp
 	${source_path}/VertexArray.cpp

--- a/source/globjects/include/globjects/AbstractUniform.h
+++ b/source/globjects/include/globjects/AbstractUniform.h
@@ -110,7 +110,7 @@ protected:
     void setValue(const Program * program, gl::GLint location, const glm::mat3x4 & value) const;
     void setValue(const Program * program, gl::GLint location, const glm::mat4x3 & value) const;
 
-    void setValue(const Program * program, gl::GLint location, const TextureHandle & value) const;
+    void setValue(const Program * program, gl::GLint location, const gl::GLuint64 & value) const;
 
     void setValue(const Program * program, gl::GLint location, const std::vector<float> & value) const;
     void setValue(const Program * program, gl::GLint location, const std::vector<int> & value) const;
@@ -140,6 +140,7 @@ protected:
     void setValue(const Program * program, gl::GLint location, const std::vector<glm::mat3x4> & value) const;
     void setValue(const Program * program, gl::GLint location, const std::vector<glm::mat4x3> & value) const;
 
+    void setValue(const Program * program, gl::GLint location, const std::vector<gl::GLuint64> & value) const;
     void setValue(const Program * program, gl::GLint location, const std::vector<TextureHandle> & value) const;
 
     template <typename T, std::size_t Count>

--- a/source/globjects/include/globjects/AbstractUniform.h
+++ b/source/globjects/include/globjects/AbstractUniform.h
@@ -111,6 +111,7 @@ protected:
     void setValue(const Program * program, gl::GLint location, const glm::mat4x3 & value) const;
 
     void setValue(const Program * program, gl::GLint location, const gl::GLuint64 & value) const;
+    void setValue(const Program * program, gl::GLint location, const TextureHandle & value) const;
 
     void setValue(const Program * program, gl::GLint location, const std::vector<float> & value) const;
     void setValue(const Program * program, gl::GLint location, const std::vector<int> & value) const;

--- a/source/globjects/include/globjects/Sampler.h
+++ b/source/globjects/include/globjects/Sampler.h
@@ -23,6 +23,7 @@ public:
     void bind(gl::GLuint unit) const;
     static void unbind(gl::GLuint unit);
 
+    void setParameter(gl::GLenum name, gl::GLenum value);
     void setParameter(gl::GLenum name, gl::GLint value);
     void setParameter(gl::GLenum name, gl::GLfloat value);
 

--- a/source/globjects/include/globjects/Texture.h
+++ b/source/globjects/include/globjects/Texture.h
@@ -119,9 +119,7 @@ public:
     void generateMipmap();
 
     TextureHandle textureHandle() const;
-    bool isResident() const;
-    TextureHandle makeResident() const;
-    void makeNonResident() const;
+    TextureHandle textureHandle(Sampler* sampler) const;
 
     void pageCommitment(gl::GLint level, gl::GLint xOffset, gl::GLint yOffset, gl::GLint zOffset, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean commit) const;
     void pageCommitment(gl::GLint level, const glm::ivec3& offset, const glm::ivec3& size, gl::GLboolean commit) const;

--- a/source/globjects/include/globjects/Texture.h
+++ b/source/globjects/include/globjects/Texture.h
@@ -10,12 +10,13 @@
 
 #include <globjects/globjects_api.h>
 #include <globjects/Object.h>
-#include <globjects/TextureHandle.h>
 
 namespace globjects 
 {
 
 class Buffer;
+class TextureHandle;
+class Sampler;
 
 
 /** \brief Wraps OpenGL texture objects.
@@ -119,7 +120,7 @@ public:
     void generateMipmap();
 
     TextureHandle textureHandle() const;
-    TextureHandle textureHandle(Sampler* sampler) const;
+    TextureHandle textureHandle(Sampler * sampler) const;
 
     void pageCommitment(gl::GLint level, gl::GLint xOffset, gl::GLint yOffset, gl::GLint zOffset, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean commit) const;
     void pageCommitment(gl::GLint level, const glm::ivec3& offset, const glm::ivec3& size, gl::GLboolean commit) const;

--- a/source/globjects/include/globjects/TextureHandle.h
+++ b/source/globjects/include/globjects/TextureHandle.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <glm/fwd.hpp>
+
 #include <glbinding/gl/types.h>
 
 #include <globjects/globjects_api.h>
@@ -14,15 +16,18 @@ class GLOBJECTS_API TextureHandle
 {
 public:
     TextureHandle();
-    explicit TextureHandle(const Texture* texture);
-    TextureHandle(const Texture* texture, const Sampler* sampler);
+    TextureHandle(gl::GLuint64 handle);
+    explicit TextureHandle(const Texture * texture);
+    TextureHandle(const Texture * texture, const Sampler * sampler);
 
     void makeResident();
     void makeNonResident();
-    bool isResident();
+    bool isResident() const;
 
     gl::GLuint64 handle() const;
     operator gl::GLuint64() const;
+
+    glm::uvec2 asUVec2() const;
 
 private:
     gl::GLuint64 m_handle;

--- a/source/globjects/include/globjects/TextureHandle.h
+++ b/source/globjects/include/globjects/TextureHandle.h
@@ -2,9 +2,30 @@
 
 #include <glbinding/gl/types.h>
 
+#include <globjects/globjects_api.h>
+
 namespace globjects 
 {
 
-using TextureHandle = gl::GLuint64;
+class Texture;
+class Sampler;
+
+class GLOBJECTS_API TextureHandle
+{
+public:
+    TextureHandle();
+    explicit TextureHandle(const Texture* texture);
+    TextureHandle(const Texture* texture, const Sampler* sampler);
+
+    void makeResident();
+    void makeNonResident();
+    bool isResident();
+
+    gl::GLuint64 handle() const;
+    operator gl::GLuint64() const;
+
+private:
+    gl::GLuint64 m_handle;
+};
 
 } // namespace globjects

--- a/source/globjects/include/globjects/TextureHandle.h
+++ b/source/globjects/include/globjects/TextureHandle.h
@@ -28,6 +28,7 @@ public:
     operator gl::GLuint64() const;
 
     glm::uvec2 asUVec2() const;
+    operator glm::uvec2() const;
 
 private:
     gl::GLuint64 m_handle;

--- a/source/globjects/source/AbstractUniform.cpp
+++ b/source/globjects/source/AbstractUniform.cpp
@@ -211,7 +211,7 @@ void AbstractUniform::setValue(const Program * program, const GLint location, co
     implementation().set(program, location, value);
 }
 
-void AbstractUniform::setValue(const Program * program, const GLint location, const TextureHandle & value) const
+void AbstractUniform::setValue(const Program * program, const GLint location, const GLuint64 & value) const
 {
     implementation().set(program, location, value);
 }
@@ -322,6 +322,11 @@ void AbstractUniform::setValue(const Program * program, const GLint location, co
 }
 
 void AbstractUniform::setValue(const Program * program, const GLint location, const std::vector<glm::mat4x3> & value) const
+{
+    implementation().set(program, location, value);
+}
+
+void AbstractUniform::setValue(const Program* program, const GLint location, const std::vector<GLuint64> & value) const
 {
     implementation().set(program, location, value);
 }

--- a/source/globjects/source/AbstractUniform.cpp
+++ b/source/globjects/source/AbstractUniform.cpp
@@ -216,6 +216,11 @@ void AbstractUniform::setValue(const Program * program, const GLint location, co
     implementation().set(program, location, value);
 }
 
+void AbstractUniform::setValue(const Program * program, const GLint location, const TextureHandle & value) const
+{
+    setValue(program, location, value.handle());
+}
+
 void AbstractUniform::setValue(const Program * program, const GLint location, const std::vector<float> & value) const
 {
     implementation().set(program, location, value);

--- a/source/globjects/source/Sampler.cpp
+++ b/source/globjects/source/Sampler.cpp
@@ -47,6 +47,11 @@ void Sampler::unbind(const GLuint unit)
     glBindSampler(unit, 0);
 }
 
+void Sampler::setParameter(const GLenum name, const GLenum value)
+{
+    glSamplerParameteri(id(), name, static_cast<GLint>(value));
+}
+
 void Sampler::setParameter(const GLenum name, const GLint value)
 {
     glSamplerParameteri(id(), name, value);

--- a/source/globjects/source/Texture.cpp
+++ b/source/globjects/source/Texture.cpp
@@ -450,26 +450,12 @@ void Texture::accept(ObjectVisitor& visitor)
 
 TextureHandle Texture::textureHandle() const
 {
-    return glGetTextureHandleARB(id());
+    return TextureHandle(this);
 }
 
-bool Texture::isResident() const
+TextureHandle Texture::textureHandle(Sampler* sampler) const
 {
-    return glIsTextureHandleResidentARB(textureHandle()) == GL_TRUE;
-}
-
-TextureHandle Texture::makeResident() const
-{
-    TextureHandle handle = textureHandle();
-
-    glMakeTextureHandleResidentARB(handle);
-
-	return handle;
-}
-
-void Texture::makeNonResident() const
-{
-    glMakeTextureHandleNonResidentARB(textureHandle());
+    return TextureHandle(this, sampler);
 }
 
 void Texture::pageCommitment(const GLint level, const GLint xOffset, const GLint yOffset, const GLint zOffset, const GLsizei width, const GLsizei height, const GLsizei depth, const GLboolean commit) const

--- a/source/globjects/source/Texture.cpp
+++ b/source/globjects/source/Texture.cpp
@@ -8,6 +8,7 @@
 
 #include <globjects/Buffer.h>
 #include <globjects/ObjectVisitor.h>
+#include <globjects/TextureHandle.h>
 
 #include "pixelformat.h"
 #include "Resource.h"
@@ -453,7 +454,7 @@ TextureHandle Texture::textureHandle() const
     return TextureHandle(this);
 }
 
-TextureHandle Texture::textureHandle(Sampler* sampler) const
+TextureHandle Texture::textureHandle(Sampler * sampler) const
 {
     return TextureHandle(this, sampler);
 }

--- a/source/globjects/source/TextureHandle.cpp
+++ b/source/globjects/source/TextureHandle.cpp
@@ -16,12 +16,17 @@ TextureHandle::TextureHandle()
 {
 }
 
-TextureHandle::TextureHandle(const Texture* texture)
+TextureHandle::TextureHandle(const GLuint64 handle)
+: m_handle(handle)
+{
+}
+
+TextureHandle::TextureHandle(const Texture * texture)
 : m_handle(glGetTextureHandleARB(texture->id()))
 {
 }
 
-TextureHandle::TextureHandle(const Texture* texture, const Sampler* sampler)
+TextureHandle::TextureHandle(const Texture * texture, const Sampler * sampler)
 : m_handle(glGetTextureSamplerHandleARB(texture->id(), sampler->id()))
 {
 }
@@ -36,7 +41,7 @@ void TextureHandle::makeNonResident()
     glMakeTextureHandleNonResidentARB(m_handle);
 }
 
-bool TextureHandle::isResident()
+bool TextureHandle::isResident() const
 {
     return glIsTextureHandleResidentARB(m_handle) == GL_TRUE;
 }
@@ -44,6 +49,11 @@ bool TextureHandle::isResident()
 GLuint64 TextureHandle::handle() const
 {
     return m_handle;
+}
+
+glm::uvec2 TextureHandle::asUVec2() const
+{
+    return glm::uvec2(static_cast<GLuint>(m_handle & 0xFFFFFFFF), m_handle >> 32);
 }
 
 TextureHandle::operator GLuint64() const

--- a/source/globjects/source/TextureHandle.cpp
+++ b/source/globjects/source/TextureHandle.cpp
@@ -1,0 +1,54 @@
+#include <globjects/TextureHandle.h>
+
+#include <glbinding/gl/functions.h>
+#include <glbinding/gl/boolean.h>
+
+#include <globjects/Texture.h>
+#include <globjects/Sampler.h>
+
+using namespace gl;
+
+namespace globjects
+{
+
+TextureHandle::TextureHandle()
+: m_handle(0)
+{
+}
+
+TextureHandle::TextureHandle(const Texture* texture)
+: m_handle(glGetTextureHandleARB(texture->id()))
+{
+}
+
+TextureHandle::TextureHandle(const Texture* texture, const Sampler* sampler)
+: m_handle(glGetTextureSamplerHandleARB(texture->id(), sampler->id()))
+{
+}
+
+void TextureHandle::makeResident()
+{
+    glMakeTextureHandleResidentARB(m_handle);
+}
+
+void TextureHandle::makeNonResident()
+{
+    glMakeTextureHandleNonResidentARB(m_handle);
+}
+
+bool TextureHandle::isResident()
+{
+    return glIsTextureHandleResidentARB(m_handle) == GL_TRUE;
+}
+
+GLuint64 TextureHandle::handle() const
+{
+    return m_handle;
+}
+
+TextureHandle::operator GLuint64() const
+{
+    return m_handle;
+}
+
+} // namespace globjects

--- a/source/globjects/source/TextureHandle.cpp
+++ b/source/globjects/source/TextureHandle.cpp
@@ -61,4 +61,9 @@ TextureHandle::operator GLuint64() const
     return m_handle;
 }
 
+TextureHandle::operator glm::uvec2() const
+{
+    return asUVec2();
+}
+
 } // namespace globjects

--- a/source/globjects/source/implementations/AbstractUniformImplementation.cpp
+++ b/source/globjects/source/implementations/AbstractUniformImplementation.cpp
@@ -33,4 +33,9 @@ AbstractUniformImplementation * AbstractUniformImplementation::get(const Abstrac
     }
 }
 
+void AbstractUniformImplementation::set(const Program* program, GLint location, const std::vector<TextureHandle> & value) const
+{
+    set(program, location, std::vector<GLuint64>{ value.begin(), value.end() });
+}
+
 } // namespace globjects

--- a/source/globjects/source/implementations/AbstractUniformImplementation.h
+++ b/source/globjects/source/implementations/AbstractUniformImplementation.h
@@ -50,7 +50,7 @@ public:
     virtual void set(const Program * program, gl::GLint location, const glm::mat3x4 & value) const = 0;
     virtual void set(const Program * program, gl::GLint location, const glm::mat4x3 & value) const = 0;
 
-    virtual void set(const Program * program, gl::GLint location, const TextureHandle & value) const = 0;
+    virtual void set(const Program * program, gl::GLint location, const gl::GLuint64 & value) const = 0;
 
     virtual void set(const Program * program, gl::GLint location, const std::vector<float> & value) const = 0;
     virtual void set(const Program * program, gl::GLint location, const std::vector<int> & value) const = 0;
@@ -80,7 +80,8 @@ public:
     virtual void set(const Program * program, gl::GLint location, const std::vector<glm::mat3x4> & value) const = 0;
     virtual void set(const Program * program, gl::GLint location, const std::vector<glm::mat4x3> & value) const = 0;
 
-    virtual void set(const Program * program, gl::GLint location, const std::vector<TextureHandle> & value) const = 0;
+    virtual void set(const Program * program, gl::GLint location, const std::vector<gl::GLuint64> & value) const = 0;
+    virtual void set(const Program * program, gl::GLint location, const std::vector<TextureHandle> & value) const;
 };
 
 } // namespace globjects

--- a/source/globjects/source/implementations/UniformImplementation_Legacy.cpp
+++ b/source/globjects/source/implementations/UniformImplementation_Legacy.cpp
@@ -293,7 +293,9 @@ void UniformImplementation_Legacy::set(const Program * program, const GLint loca
 void UniformImplementation_Legacy::set(const Program * program, const GLint location, const std::vector<TextureHandle> & value) const
 {
     program->use();
-    glUniformHandleui64vARB(location, static_cast<GLint>(value.size()), value.data());
+    std::vector<GLuint64> handleValues(value.size());
+    std::transform(value.begin(), value.end(), handleValues.begin(), [](const TextureHandle& textureHandle) { return textureHandle.handle(); });
+    glUniformHandleui64vARB(location, static_cast<GLint>(value.size()), handleValues.data());
 }
 
 } // namespace globjects

--- a/source/globjects/source/implementations/UniformImplementation_Legacy.cpp
+++ b/source/globjects/source/implementations/UniformImplementation_Legacy.cpp
@@ -146,7 +146,7 @@ void UniformImplementation_Legacy::set(const Program * program, const GLint loca
     glUniformMatrix4x3fv(location, 1, GL_FALSE, glm::value_ptr(value));
 }
 
-void UniformImplementation_Legacy::set(const Program * program, const GLint location, const TextureHandle & value) const
+void UniformImplementation_Legacy::set(const Program * program, const GLint location, const GLuint64 & value) const
 {
     program->use();
     glUniformHandleui64ARB(location, value);
@@ -290,12 +290,10 @@ void UniformImplementation_Legacy::set(const Program * program, const GLint loca
     glUniformMatrix4x3fv(location, static_cast<GLint>(value.size()), GL_FALSE, reinterpret_cast<const float*>(value.data()));
 }
 
-void UniformImplementation_Legacy::set(const Program * program, const GLint location, const std::vector<TextureHandle> & value) const
+void UniformImplementation_Legacy::set(const Program* program, const GLint location, const std::vector<GLuint64> & value) const
 {
     program->use();
-    std::vector<GLuint64> handleValues(value.size());
-    std::transform(value.begin(), value.end(), handleValues.begin(), [](const TextureHandle& textureHandle) { return textureHandle.handle(); });
-    glUniformHandleui64vARB(location, static_cast<GLint>(value.size()), handleValues.data());
+    glUniformHandleui64vARB(location, static_cast<GLint>(value.size()), value.data());
 }
 
 } // namespace globjects

--- a/source/globjects/source/implementations/UniformImplementation_Legacy.h
+++ b/source/globjects/source/implementations/UniformImplementation_Legacy.h
@@ -41,7 +41,7 @@ public:
     virtual void set(const Program * program, gl::GLint location, const glm::mat3x4 & value) const override;
     virtual void set(const Program * program, gl::GLint location, const glm::mat4x3 & value) const override;
 
-    virtual void set(const Program * program, gl::GLint location, const TextureHandle & value) const override;
+    virtual void set(const Program * program, gl::GLint location, const gl::GLuint64 & value) const override;
 
     virtual void set(const Program * program, gl::GLint location, const std::vector<float> & value) const override;
     virtual void set(const Program * program, gl::GLint location, const std::vector<int> & value) const override;
@@ -71,7 +71,7 @@ public:
     virtual void set(const Program * program, gl::GLint location, const std::vector<glm::mat3x4> & value) const override;
     virtual void set(const Program * program, gl::GLint location, const std::vector<glm::mat4x3> & value) const override;
 
-    virtual void set(const Program * program, gl::GLint location, const std::vector<TextureHandle> & value) const override;
+    virtual void set(const Program * program, gl::GLint location, const std::vector<gl::GLuint64> & value) const override;
 };
 
 } // namespace globjects

--- a/source/globjects/source/implementations/UniformImplementation_SeparateShaderObjectsARB.cpp
+++ b/source/globjects/source/implementations/UniformImplementation_SeparateShaderObjectsARB.cpp
@@ -124,7 +124,7 @@ void UniformImplementation_SeparateShaderObjectsARB::set(const Program * program
     glProgramUniformMatrix4x3fv(program->id(), location, 1, GL_FALSE, glm::value_ptr(value));
 }
 
-void UniformImplementation_SeparateShaderObjectsARB::set(const Program * program, const GLint location, const TextureHandle & value) const
+void UniformImplementation_SeparateShaderObjectsARB::set(const Program * program, const GLint location, const GLuint64 & value) const
 {
     glProgramUniformHandleui64ARB(program->id(), location, value);
 }
@@ -245,11 +245,9 @@ void UniformImplementation_SeparateShaderObjectsARB::set(const Program * program
     glProgramUniformMatrix4x3fv(program->id(), location, static_cast<GLint>(value.size()), GL_FALSE, reinterpret_cast<const float*>(value.data()));
 }
 
-void UniformImplementation_SeparateShaderObjectsARB::set(const Program * program, const GLint location, const std::vector<TextureHandle> & value) const
+void UniformImplementation_SeparateShaderObjectsARB::set(const Program* program, const GLint location, const std::vector<GLuint64> & value) const
 {
-    std::vector<GLuint64> handleValues(value.size());
-    std::transform(value.begin(), value.end(), handleValues.begin(), [](const TextureHandle& textureHandle) { return textureHandle.handle(); });
-    glProgramUniformHandleui64vARB(program->id(), location, static_cast<GLint>(handleValues.size()), handleValues.data());
+    glProgramUniformHandleui64vARB(program->id(), location, static_cast<GLint>(value.size()), value.data());
 }
 
 } // namespace globjects

--- a/source/globjects/source/implementations/UniformImplementation_SeparateShaderObjectsARB.cpp
+++ b/source/globjects/source/implementations/UniformImplementation_SeparateShaderObjectsARB.cpp
@@ -247,8 +247,9 @@ void UniformImplementation_SeparateShaderObjectsARB::set(const Program * program
 
 void UniformImplementation_SeparateShaderObjectsARB::set(const Program * program, const GLint location, const std::vector<TextureHandle> & value) const
 {
-    const TextureHandle * handle = value.data();
-    glProgramUniformHandleui64vARB(program->id(), location, static_cast<GLint>(value.size()), handle);
+    std::vector<GLuint64> handleValues(value.size());
+    std::transform(value.begin(), value.end(), handleValues.begin(), [](const TextureHandle& textureHandle) { return textureHandle.handle(); });
+    glProgramUniformHandleui64vARB(program->id(), location, static_cast<GLint>(handleValues.size()), handleValues.data());
 }
 
 } // namespace globjects

--- a/source/globjects/source/implementations/UniformImplementation_SeparateShaderObjectsARB.h
+++ b/source/globjects/source/implementations/UniformImplementation_SeparateShaderObjectsARB.h
@@ -40,7 +40,7 @@ public:
     virtual void set(const Program * program, gl::GLint location, const glm::mat3x4 & value) const override;
     virtual void set(const Program * program, gl::GLint location, const glm::mat4x3 & value) const override;
 
-    virtual void set(const Program * program, gl::GLint location, const TextureHandle & value) const override;
+    virtual void set(const Program * program, gl::GLint location, const gl::GLuint64 & value) const override;
 
     virtual void set(const Program * program, gl::GLint location, const std::vector<float> & value) const override;
     virtual void set(const Program * program, gl::GLint location, const std::vector<int> & value) const override;
@@ -70,7 +70,7 @@ public:
     virtual void set(const Program * program, gl::GLint location, const std::vector<glm::mat3x4> & value) const override;
     virtual void set(const Program * program, gl::GLint location, const std::vector<glm::mat4x3> & value) const override;
 
-    virtual void set(const Program * program, gl::GLint location, const std::vector<TextureHandle> & value) const override;
+    virtual void set(const Program * program, gl::GLint location, const std::vector<gl::GLuint64> & value) const override;
 };
 
 } // namespace globjects


### PR DESCRIPTION
This replaces the original typdef with a class that represents either a texture handle or a combined texture sampler handle, i.e. wraps calls to `glGetTextureHandleARB` and `glGetTextureSamplerHandleARB`. The original solution did not support the latter.