### PR TITLE
Fix iterator invalidation in ChangeListener

### DIFF
--- a/source/globjects/source/base/ChangeListener.cpp
+++ b/source/globjects/source/base/ChangeListener.cpp
@@ -7,9 +7,10 @@ namespace globjects
 
 ChangeListener::~ChangeListener()
 {
-    for (Changeable * subject : m_subjects)
+    while (!m_subjects.empty())
     {
-        subject->deregisterListener(this);
+        // calls removeSubject
+        (*m_subjects.begin())->deregisterListener(this);
     }
 }
 


### PR DESCRIPTION
Since `Changaable::deregisterListener` calls `ChangeListener::removeSubject`, the `m_subjects` container is modified and thus the iterators used in the for loop are invalidated, causing an assertion failure in debug mode on MSVC 2015.