### PR TITLE
Make Program Changeable

### DIFF
--- a/source/globjects/include/globjects/Program.h
+++ b/source/globjects/include/globjects/Program.h
@@ -7,6 +7,7 @@
 #include <glm/vec3.hpp>
 
 #include <globjects/base/ChangeListener.h>
+#include <globjects/base/Changeable.h>
 #include <globjects/base/ref_ptr.h>
 
 #include <globjects/globjects_api.h>
@@ -72,7 +73,7 @@ class Uniform;
     \see http://www.opengl.org/wiki/Program_Object
     \see Shader
  */
-class GLOBJECTS_API Program : public Object, protected ChangeListener
+class GLOBJECTS_API Program : public Object, protected ChangeListener, public Changeable
 {
     friend class UniformBlock;
     friend class ProgramBinaryImplementation_GetProgramBinaryARB;

--- a/source/globjects/source/Program.cpp
+++ b/source/globjects/source/Program.cpp
@@ -160,7 +160,10 @@ void Program::link() const
     m_linked = false;
 
     if (!binaryImplementation().updateProgramLinkSource(this))
+    {
+        changed();
         return;
+    }
 
     glLinkProgram(id());
 
@@ -169,6 +172,8 @@ void Program::link() const
 
     updateUniforms();
     updateUniformBlockBindings();
+
+    changed();
 }
 
 bool Program::compileAttachedShaders() const


### PR DESCRIPTION
A `Program` is marked 'changed' when `link()` was called. This is useful in cases where the program source is constructed from complex, dynamic `StringSource` hierarchies.