### PR TITLE
Fix so that examples/ build successfully on macOS

### DIFF
--- a/source/examples/computeshader/main.cpp
+++ b/source/examples/computeshader/main.cpp
@@ -119,7 +119,7 @@ void key_callback(GLFWwindow * window, int key, int /*scancode*/, int action, in
 int main()
 {
 #ifdef SYSTEM_DARWIN
-    critical() << "macOS does currently not support compute shader (OpenGL 4.3. required)."
+    globjects::critical() << "macOS does currently not support compute shader (OpenGL 4.3. required).";
     return 0;
 #endif
 


### PR DESCRIPTION
Currently the examples fail to build via CMake due to the following line computeshader/main.cpp