### PR TITLE
Add convenience methods to specify Buffer data from a plain struct

### DIFF
--- a/source/globjects/include/globjects/Buffer.h
+++ b/source/globjects/include/globjects/Buffer.h
@@ -93,6 +93,11 @@ public:
         \see https://www.opengl.org/sdk/docs/man4/xhtml/glBufferData.xml
     */
     void setData(gl::GLsizeiptr size, const gl::GLvoid * data, gl::GLenum usage);
+
+    /** \brief Convenience method to simplify passing of data in form of a POD struct.
+    */
+    template <typename T>
+    void setData(const T & data, gl::GLenum usage);
     
     /** \brief Convenience method to simplify passing of data in form of an std::vector.
     */
@@ -103,6 +108,7 @@ public:
     */
     template <typename T, std::size_t Count>
     void setData(const std::array<T, Count> & data, gl::GLenum usage);
+
     /** \brief Wraps the OpenGL function glBufferSubData.
         Writes data only to a defined area of the memory.
         \param size size of memory in bytes
@@ -111,6 +117,11 @@ public:
         \see http://www.opengl.org/sdk/docs/man/xhtml/glBufferSubData.xml
     */
     void setSubData(gl::GLintptr offset, gl::GLsizeiptr size, const gl::GLvoid* data = nullptr);
+
+    /** \brief Convenience method to simplify passing of data in form of a POD struct.
+    */
+    template <typename T>
+    void setSubData(const T & data, gl::GLintptr offset = 0);
     
     /** \brief Convenience method to simplify passing of data in form of an std::vector.
     */
@@ -129,6 +140,11 @@ public:
         \see www.opengl.org/sdk/docs/man/xhtml/glBufferStorage.xml
     */
     void setStorage(gl::GLsizeiptr size, const gl::GLvoid * data, gl::BufferStorageMask flags);
+
+    /** \brief Convenience method to simplify passing of data in form of a POD struct.
+    */
+    template <typename T>
+    void setStorage(const T & data, gl::BufferStorageMask flags);
     
     /** \brief Convenience method to simplify passing of data in form of an std::vector.
     */
@@ -238,15 +254,29 @@ public:
     const void * getPointer(gl::GLenum pname) const;
     void * getPointer(gl::GLenum pname);
 
+    /** \brief Wraps the OpenGL function glGetBufferSubData.
+        Retrieves the contents of the buffers data store.
+        \param offset offset from the beginning of the buffer in bytes
+        \param size size of memory in bytes
+        \param data memory location to store the data
+        \see http://www.opengl.org/sdk/docs/man/xhtml/glGetBufferSubData.xml
+    */
     void getSubData(gl::GLintptr offset, gl::GLsizeiptr size, void * data) const;
 
+    /** \brief Convenience method to simplify getting of data in form of a POD struct.
+    */
     template <typename T>
-    const std::vector<T> getSubData(gl::GLsizeiptr size, gl::GLintptr offset = 0) const;
+    T getSubData(gl::GLintptr offset = 0) const;
+
+    /** \brief Convenience method to simplify getting of data in form of an std::vector.
+    */
+    template <typename T>
+    std::vector<T> getSubData(gl::GLsizeiptr count, gl::GLintptr offset = 0) const;
     
-    /** \brief Convenience method to simplify passing of data in form of an std::array.
+    /** \brief Convenience method to simplify getting of data in form of an std::array.
     */
     template <typename T, std::size_t Count>
-    const std::array<T, Count> getSubData(gl::GLintptr offset = 0) const;
+    std::array<T, Count> getSubData(gl::GLintptr offset = 0) const;
 
     /** \brief Wraps the OpenGL function gl::glInvalidateBufferData.
         \see https://www.opengl.org/sdk/docs/man/html/glInvalidateBufferData.xhtml

--- a/source/globjects/include/globjects/Buffer.h
+++ b/source/globjects/include/globjects/Buffer.h
@@ -263,11 +263,6 @@ public:
     */
     void getSubData(gl::GLintptr offset, gl::GLsizeiptr size, void * data) const;
 
-    /** \brief Convenience method to simplify getting of data in form of a POD struct.
-    */
-    template <typename T>
-    T getSubData(gl::GLintptr offset = 0) const;
-
     /** \brief Convenience method to simplify getting of data in form of an std::vector.
     */
     template <typename T>

--- a/source/globjects/include/globjects/Buffer.inl
+++ b/source/globjects/include/globjects/Buffer.inl
@@ -5,6 +5,11 @@
 namespace globjects
 {
 
+template <typename T>
+void Buffer::setData(const T & data, gl::GLenum usage)
+{
+    setData(static_cast<gl::GLsizeiptr>(sizeof(T)), &data, usage);
+}
 
 template <typename T>
 void Buffer::setData(const std::vector<T> & data, gl::GLenum usage)
@@ -16,6 +21,12 @@ template <typename T, std::size_t Count>
 void Buffer::setData(const std::array<T, Count> & data, gl::GLenum usage)
 {
     setData(static_cast<gl::GLsizeiptr>(Count * sizeof(T)), data.data(), usage);
+}
+
+template <typename T>
+void Buffer::setSubData(const T & data, gl::GLintptr offset)
+{
+    setSubData(offset, static_cast<gl::GLsizei>(sizeof(T)), &data);
 }
 
 template <typename T>
@@ -31,6 +42,12 @@ void Buffer::setSubData(const std::array<T, Count> & data, gl::GLintptr offset)
 }
 
 template <typename T>
+void Buffer::setStorage(const T & data, gl::BufferStorageMask flags)
+{
+    setStorage(static_cast<gl::GLsizei>(sizeof(T)), &data, flags);
+}
+
+template <typename T>
 void Buffer::setStorage(const std::vector<T> & data, gl::BufferStorageMask flags)
 {
     setStorage(static_cast<gl::GLsizei>(data.size() * sizeof(T)), data.data(), flags);
@@ -43,17 +60,27 @@ void Buffer::setStorage(const std::array<T, Count> & data, gl::BufferStorageMask
 }
 
 template <typename T>
-const std::vector<T> Buffer::getSubData(gl::GLsizeiptr size, gl::GLintptr offset) const
+T Buffer::getSubData(gl::GLintptr offset) const
 {
-    std::vector<T> data(size);
+    T data;
 
-    getSubData(offset, size, data.data());
+    getSubData(offset, sizeof(T), &data);
+
+    return data;
+}
+
+template <typename T>
+std::vector<T> Buffer::getSubData(gl::GLsizeiptr count, gl::GLintptr offset) const
+{
+    std::vector<T> data(count);
+
+    getSubData(offset, static_cast<gl::GLsizeiptr>(count * sizeof(T)), data.data());
 
     return data;
 }
 
 template <typename T, std::size_t Count>
-const std::array<T, Count> Buffer::getSubData(gl::GLintptr offset) const
+std::array<T, Count> Buffer::getSubData(gl::GLintptr offset) const
 {
     std::array<T, Count> data;
 

--- a/source/globjects/include/globjects/Buffer.inl
+++ b/source/globjects/include/globjects/Buffer.inl
@@ -60,16 +60,6 @@ void Buffer::setStorage(const std::array<T, Count> & data, gl::BufferStorageMask
 }
 
 template <typename T>
-T Buffer::getSubData(gl::GLintptr offset) const
-{
-    T data;
-
-    getSubData(offset, sizeof(T), &data);
-
-    return data;
-}
-
-template <typename T>
 std::vector<T> Buffer::getSubData(gl::GLsizeiptr count, gl::GLintptr offset) const
 {
     std::vector<T> data(count);


### PR DESCRIPTION
This simplifies data upload to buffers containing control structures (e.g., uniform buffers)
Example:
```
struct UniformBufferData
{
    glm::mat viewProjection;
    glm::vec2 viewport;
    float viewport;
};

auto data = UniformBufferData{ ... };
myBuffer->setData(data, GL_STATIC_DRAW); // new
myBuffer->setData(sizeof(UniformBufferData), &data, GL_STATIC_DRAW); // old
```