### PR TITLE
explicitly paint to see effect of shader change

### DIFF
--- a/data/qt-example/shader.frag
+++ b/data/qt-example/shader.frag
@@ -8,4 +8,5 @@ in vec4 color;
 void main()
 {
     fragColor = color;
+    fragColor = vec4(fragColor.x, 0.0, fragColor.y, 1.0);
 }

--- a/source/examples/qtexample/WindowQt.cpp
+++ b/source/examples/qtexample/WindowQt.cpp
@@ -170,6 +170,7 @@ void WindowQt::resizeGL(QResizeEvent *)
 
 void WindowQt::paintGL()
 {
+    updateGL();
 }
 
 void WindowQt::enterEvent(QEvent *)

--- a/source/examples/qtexample/main.cpp
+++ b/source/examples/qtexample/main.cpp
@@ -122,16 +122,20 @@ public:
     {
         makeCurrent();
 
+        bool reloadedShaders = false;
         switch (event->key())
         {
         case Qt::Key_F5:
             m_vertexShaderSource->reload();
             m_fragmentShaderSource->reload();
+            reloadedShaders = true;
             break;
         default:
             break;
         }
         doneCurrent();
+        if(reloadedShaders)
+            paint();
     }
 
 

--- a/source/examples/qtexample/main.cpp
+++ b/source/examples/qtexample/main.cpp
@@ -122,20 +122,17 @@ public:
     {
         makeCurrent();
 
-        bool reloadedShaders = false;
         switch (event->key())
         {
         case Qt::Key_F5:
             m_vertexShaderSource->reload();
             m_fragmentShaderSource->reload();
-            reloadedShaders = true;
+            updateGL();
             break;
         default:
             break;
         }
         doneCurrent();
-        if(reloadedShaders)
-            paint();
     }
 
 

--- a/source/examples/qtexample/main.cpp
+++ b/source/examples/qtexample/main.cpp
@@ -129,6 +129,9 @@ public:
             m_fragmentShaderSource->reload();
             updateGL();
             break;
+        case Qt::Key_Escape:
+            qApp->quit();
+            break;
         default:
             break;
         }


### PR DESCRIPTION
At least for me on windows 10 with either OpenGL 3.x or 4.x, the window did not get updated until dragging off-screen or minimizing. 
Explicitly calling paint() remedies this; the window changes shaders instantaneously on F5.