### PR TITLE
Fix missing initialization of AbstractUniform::m_location

### DIFF
--- a/source/globjects/source/AbstractUniform.cpp
+++ b/source/globjects/source/AbstractUniform.cpp
@@ -37,6 +37,7 @@ AbstractUniform::AbstractUniform(const Program * program, const GLint location, 
 : m_identity(location)
 , m_program(program)
 , m_type(type)
+, m_location(-1)
 {
 }
 
@@ -44,6 +45,7 @@ AbstractUniform::AbstractUniform(const Program * program, const std::string & na
 : m_identity(name)
 , m_program(program)
 , m_type(type)
+, m_location(-1)
 {
 }
 


### PR DESCRIPTION
Otherwise, depending on the value, this check may fail:
```
template<typename T>
void Uniform<T>::updateAt(gl::GLint location) const
{
    if (location < 0)
    {
        return;
    }

    setValue(location, m_value);
}
```