### PR TITLE
Deinitialize objects of examples in correct order

### DIFF
--- a/source/examples/computeshader/main.cpp
+++ b/source/examples/computeshader/main.cpp
@@ -97,19 +97,19 @@ void deinitialize()
     g_texture.reset(nullptr);
 
     g_program.reset(nullptr);
-    g_vertexShaderSource.reset(nullptr);
-    g_vertexShaderTemplate.reset(nullptr);
     g_vertexShader.reset(nullptr);
-    g_fragmentShaderSource.reset(nullptr);
-    g_fragmentShaderTemplate.reset(nullptr);
+    g_vertexShaderTemplate.reset(nullptr);
+    g_vertexShaderSource.reset(nullptr);
     g_fragmentShader.reset(nullptr);
+    g_fragmentShaderTemplate.reset(nullptr);
+    g_fragmentShaderSource.reset(nullptr);
 
     g_quad.reset(nullptr);
 
     g_computeProgram.reset(nullptr);
-    g_shaderSource.reset(nullptr);
-    g_shaderTemplate.reset(nullptr);
     g_shader.reset(nullptr);
+    g_shaderTemplate.reset(nullptr);
+    g_shaderSource.reset(nullptr);
 }
 
 void draw()

--- a/source/examples/programpipelines/main.cpp
+++ b/source/examples/programpipelines/main.cpp
@@ -108,15 +108,15 @@ void initialize()
 void deinitialize()
 {
     g_cornerBuffer.reset(nullptr);
+    g_programPipeline.reset(nullptr);
     g_vertexProgram.reset(nullptr);
     g_fragmentProgram.reset(nullptr);
-    g_vertexShaderSource.reset(nullptr);
-    g_vertexShaderTemplate.reset(nullptr);
     g_vertexShader.reset(nullptr);
-    g_fragmentShaderSource.reset(nullptr);
-    g_fragmentShaderTemplate.reset(nullptr);
+    g_vertexShaderTemplate.reset(nullptr);
+    g_vertexShaderSource.reset(nullptr);
     g_fragmentShader.reset(nullptr);
-    g_programPipeline.reset(nullptr);
+    g_fragmentShaderTemplate.reset(nullptr);
+    g_fragmentShaderSource.reset(nullptr);
     g_vao.reset(nullptr);
 }
 

--- a/source/examples/shaderincludes/main.cpp
+++ b/source/examples/shaderincludes/main.cpp
@@ -71,15 +71,15 @@ void initialize()
 void deinitialize()
 {
     g_program.reset(nullptr);
-    g_vertexShaderSource.reset(nullptr);
-    g_vertexShaderTemplate.reset(nullptr);
     g_vertexShader.reset(nullptr);
-    g_fragmentShaderSource.reset(nullptr);
-    g_fragmentShaderTemplate.reset(nullptr);
+    g_vertexShaderTemplate.reset(nullptr);
+    g_vertexShaderSource.reset(nullptr);
     g_fragmentShader.reset(nullptr);
+    g_fragmentShaderTemplate.reset(nullptr);
+    g_fragmentShaderSource.reset(nullptr);
 
-    g_namedStringSource.reset(nullptr);
     g_namedString.reset(nullptr);
+    g_namedStringSource.reset(nullptr);
 
     g_quad.reset(nullptr);
 }

--- a/source/examples/sparsetexture/main.cpp
+++ b/source/examples/sparsetexture/main.cpp
@@ -131,12 +131,12 @@ void deinitialize()
     g_texture.reset(nullptr);
 
     g_program.reset(nullptr);
-    g_vertexShaderSource.reset(nullptr);
-    g_vertexShaderTemplate.reset(nullptr);
     g_vertexShader.reset(nullptr);
-    g_fragmentShaderSource.reset(nullptr);
-    g_fragmentShaderTemplate.reset(nullptr);
+    g_vertexShaderTemplate.reset(nullptr);
+    g_vertexShaderSource.reset(nullptr);
     g_fragmentShader.reset(nullptr);
+    g_fragmentShaderTemplate.reset(nullptr);
+    g_fragmentShaderSource.reset(nullptr);
 
     g_quad.reset(nullptr);
 }

--- a/source/examples/ssbo/main.cpp
+++ b/source/examples/ssbo/main.cpp
@@ -91,12 +91,12 @@ void deinitialize()
     g_buffer.reset(nullptr);
 
     g_program.reset(nullptr);
-    g_vertexShaderSource.reset(nullptr);
-    g_vertexShaderTemplate.reset(nullptr);
     g_vertexShader.reset(nullptr);
-    g_fragmentShaderSource.reset(nullptr);
-    g_fragmentShaderTemplate.reset(nullptr);
+    g_vertexShaderTemplate.reset(nullptr);
+    g_vertexShaderSource.reset(nullptr);
     g_fragmentShader.reset(nullptr);
+    g_fragmentShaderTemplate.reset(nullptr);
+    g_fragmentShaderSource.reset(nullptr);
 }
 
 void draw()

--- a/source/examples/states/main.cpp
+++ b/source/examples/states/main.cpp
@@ -107,12 +107,12 @@ void initialize()
 void deinitialize()
 {
     g_shaderProgram.reset(nullptr);
-    g_vertexShaderSource.reset(nullptr);
-    g_vertexShaderTemplate.reset(nullptr);
     g_vertexShader.reset(nullptr);
-    g_fragmentShaderSource.reset(nullptr);
-    g_fragmentShaderTemplate.reset(nullptr);
+    g_vertexShaderTemplate.reset(nullptr);
+    g_vertexShaderSource.reset(nullptr);
     g_fragmentShader.reset(nullptr);
+    g_fragmentShaderTemplate.reset(nullptr);
+    g_fragmentShaderSource.reset(nullptr);
 
     g_vao.reset(nullptr);
     g_buffer.reset(nullptr);

--- a/source/examples/tessellation/main.cpp
+++ b/source/examples/tessellation/main.cpp
@@ -125,24 +125,24 @@ void deinitialize()
     g_sphere.reset(nullptr);
 
     g_program.reset(nullptr);
-    g_vertexShaderSource.reset(nullptr);
-    g_vertexShaderTemplate.reset(nullptr);
     g_vertexShader.reset(nullptr);
-    g_tessControlShaderSource.reset(nullptr);
-    g_tessControlShaderTemplate.reset(nullptr);
+    g_vertexShaderTemplate.reset(nullptr);
+    g_vertexShaderSource.reset(nullptr);
     g_tessControlShader.reset(nullptr);
-    g_tessEvaluationShaderSource.reset(nullptr);
-    g_tessEvaluationShaderTemplate.reset(nullptr);
+    g_tessControlShaderTemplate.reset(nullptr);
+    g_tessControlShaderSource.reset(nullptr);
     g_tessEvaluationShader.reset(nullptr);
-    g_geometryShaderSource.reset(nullptr);
-    g_geometryShaderTemplate.reset(nullptr);
+    g_tessEvaluationShaderTemplate.reset(nullptr);
+    g_tessEvaluationShaderSource.reset(nullptr);
     g_geometryShader.reset(nullptr);
-    g_fragmentShaderSource.reset(nullptr);
-    g_fragmentShaderTemplate.reset(nullptr);
+    g_geometryShaderTemplate.reset(nullptr);
+    g_geometryShaderSource.reset(nullptr);
     g_fragmentShader.reset(nullptr);
-    g_phongShaderSource.reset(nullptr);
-    g_phongShaderTemplate.reset(nullptr);
+    g_fragmentShaderTemplate.reset(nullptr);
+    g_fragmentShaderSource.reset(nullptr);
     g_phongShader.reset(nullptr);
+    g_phongShaderTemplate.reset(nullptr);
+    g_phongShaderSource.reset(nullptr);
 
     g_icosahedron.reset(nullptr);
 }

--- a/source/examples/texture/main.cpp
+++ b/source/examples/texture/main.cpp
@@ -79,12 +79,12 @@ void deinitialize()
     g_texture.reset(nullptr);
 
     g_program.reset(nullptr);
-    g_vertexShaderSource.reset(nullptr);
-    g_vertexShaderTemplate.reset(nullptr);
     g_vertexShader.reset(nullptr);
-    g_fragmentShaderSource.reset(nullptr);
-    g_fragmentShaderTemplate.reset(nullptr);
+    g_vertexShaderTemplate.reset(nullptr);
+    g_vertexShaderSource.reset(nullptr);
     g_fragmentShader.reset(nullptr);
+    g_fragmentShaderTemplate.reset(nullptr);
+    g_fragmentShaderSource.reset(nullptr);
 
     g_quad.reset(nullptr);
 }

--- a/source/examples/transformfeedback/main.cpp
+++ b/source/examples/transformfeedback/main.cpp
@@ -140,20 +140,20 @@ void deinitialize()
 {
     g_vao.reset(nullptr);
 
-    g_transformFeedbackProgram.reset(nullptr);
     g_transformFeedback.reset(nullptr);
+    g_transformFeedbackProgram.reset(nullptr);
     g_shaderProgram.reset(nullptr);
 
-    g_feedbackShaderSource.reset(nullptr);
-    g_feedbackShaderTemplate.reset(nullptr);
     g_feedbackShader.reset(nullptr);
+    g_feedbackShaderTemplate.reset(nullptr);
+    g_feedbackShaderSource.reset(nullptr);
 
-    g_vertexShaderSource.reset(nullptr);
-    g_vertexShaderTemplate.reset(nullptr);
     g_vertexShader.reset(nullptr);
-    g_fragmentShaderSource.reset(nullptr);
-    g_fragmentShaderTemplate.reset(nullptr);
+    g_vertexShaderTemplate.reset(nullptr);
+    g_vertexShaderSource.reset(nullptr);
     g_fragmentShader.reset(nullptr);
+    g_fragmentShaderTemplate.reset(nullptr);
+    g_fragmentShaderSource.reset(nullptr);
 
     g_vertexBuffer1.reset(nullptr);
     g_vertexBuffer2.reset(nullptr);


### PR DESCRIPTION
Affects all examples except commandlineoutput and qtexample. Fixes crash on closing the application.