### PR TITLE
Fix examples for macOS

### DIFF
--- a/source/examples/commandlineoutput/main.cpp
+++ b/source/examples/commandlineoutput/main.cpp
@@ -42,8 +42,9 @@ int main(int /*argc*/, char * /*argv*/[])
     glfwSetErrorCallback(error);
     glfwWindowHint(GLFW_VISIBLE, false);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, true);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
     // Create a context and, if valid, make it current
     GLFWwindow * offscreen_context = glfwCreateWindow(320, 240, "globjects Command Line Output", NULL, NULL);

--- a/source/examples/programpipelines/main.cpp
+++ b/source/examples/programpipelines/main.cpp
@@ -157,8 +157,9 @@ int main(int /*argc*/, char * /*argv*/[])
     glfwSetErrorCallback(error);
     glfwDefaultWindowHints();
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, true);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
     // Create a context and, if valid, make it current
     GLFWwindow * window = glfwCreateWindow(640, 480, "globjects Progam Pipelines", NULL, NULL);

--- a/source/examples/shaderincludes/main.cpp
+++ b/source/examples/shaderincludes/main.cpp
@@ -125,8 +125,9 @@ int main(int /*argc*/, char * /*argv*/[])
     glfwSetErrorCallback(error);
     glfwDefaultWindowHints();
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, true);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
     // Create a context and, if valid, make it current
     GLFWwindow * window = glfwCreateWindow(640, 480, "globjects Shader Includes", NULL, NULL);

--- a/source/examples/sparsetexture/main.cpp
+++ b/source/examples/sparsetexture/main.cpp
@@ -207,8 +207,9 @@ int main(int /*argc*/, char * /*argv*/[])
     glfwSetErrorCallback(error);
     glfwDefaultWindowHints();
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, true);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
     // Create a context and, if valid, make it current
     GLFWwindow * window = glfwCreateWindow(640, 480, "globjects Sparse Textures", NULL, NULL);

--- a/source/examples/ssbo/main.cpp
+++ b/source/examples/ssbo/main.cpp
@@ -139,8 +139,9 @@ int main(int /*argc*/, char * /*argv*/[])
     glfwSetErrorCallback(error);
     glfwDefaultWindowHints();
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, true);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
     // Create a context and, if valid, make it current
     GLFWwindow * window = glfwCreateWindow(640, 480, "globjects Shader Storage Buffer Objects", NULL, NULL);

--- a/source/examples/states/main.cpp
+++ b/source/examples/states/main.cpp
@@ -205,8 +205,9 @@ int main(int /*argc*/, char * /*argv*/[])
     glfwSetErrorCallback(error);
     glfwDefaultWindowHints();
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, true);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
     // Create a context and, if valid, make it current
     GLFWwindow * window = glfwCreateWindow(640, 480, "globjects States", NULL, NULL);

--- a/source/examples/tessellation/main.cpp
+++ b/source/examples/tessellation/main.cpp
@@ -210,6 +210,7 @@ int main(int /*argc*/, char * /*argv*/[])
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, true);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
     // Create a context and, if valid, make it current
     GLFWwindow * window = glfwCreateWindow(640, 480, "globjects Tessellation", NULL, NULL);

--- a/source/examples/texture/main.cpp
+++ b/source/examples/texture/main.cpp
@@ -124,8 +124,9 @@ int main(int /*argc*/, char * /*argv*/[])
     glfwSetErrorCallback(error);
     glfwDefaultWindowHints();
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 1);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, true);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
     // Create a context and, if valid, make it current
     GLFWwindow * window = glfwCreateWindow(640, 480, "globjects Texture", NULL, NULL);

--- a/source/examples/transformfeedback/main.cpp
+++ b/source/examples/transformfeedback/main.cpp
@@ -239,6 +239,7 @@ int main(int /*argc*/, char * /*argv*/[])
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, true);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
     // Create a context and, if valid, make it current
     GLFWwindow * window = glfwCreateWindow(640, 480, "globjects Transform Feedback", NULL, NULL);


### PR DESCRIPTION
*  Bump OpenGL version from 3.1 to 3.2, where necessary
*  Use core context for all examples