### PR TITLE
Fix endless loop in CompositeStringSource destructor

### DIFF
--- a/source/globjects/source/base/CompositeStringSource.cpp
+++ b/source/globjects/source/base/CompositeStringSource.cpp
@@ -25,9 +25,9 @@ CompositeStringSource::CompositeStringSource(const std::vector<AbstractStringSou
 
 CompositeStringSource::~CompositeStringSource()
 {
-    while (!m_sources.empty())
+    for (auto source : m_sources)
     {
-        (*m_sources.begin())->deregisterListener(this);
+        source->deregisterListener(this);
     }
 }
 


### PR DESCRIPTION
`deregisterListener` and subsequent `removeSubject` do not remove the source, hence this loops forever.