### PR TITLE
Split off TextureStorageMultisampleImplementation

### DIFF
--- a/source/globjects/CMakeLists.txt
+++ b/source/globjects/CMakeLists.txt
@@ -207,6 +207,17 @@ set(sources
     ${source_path}/implementations/TextureStorageImplementation_Fallback.cpp
     ${source_path}/implementations/TextureStorageImplementation_Fallback.h
 
+    ${source_path}/implementations/AbstractTextureStorageMultisampleImplementation.cpp
+    ${source_path}/implementations/AbstractTextureStorageMultisampleImplementation.h
+    ${source_path}/implementations/TextureStorageMultisampleImplementation_DirectStateAccessARB.cpp
+    ${source_path}/implementations/TextureStorageMultisampleImplementation_DirectStateAccessARB.h
+    ${source_path}/implementations/TextureStorageMultisampleImplementation_DirectStateAccessEXT.cpp
+    ${source_path}/implementations/TextureStorageMultisampleImplementation_DirectStateAccessEXT.h
+    ${source_path}/implementations/TextureStorageMultisampleImplementation_Legacy.cpp
+    ${source_path}/implementations/TextureStorageMultisampleImplementation_Legacy.h
+    ${source_path}/implementations/TextureStorageMultisampleImplementation_Fallback.cpp
+    ${source_path}/implementations/TextureStorageMultisampleImplementation_Fallback.h
+
     ${source_path}/implementations/AbstractUniformImplementation.cpp
     ${source_path}/implementations/AbstractUniformImplementation.h
     ${source_path}/implementations/UniformImplementation_Legacy.cpp

--- a/source/globjects/include/globjects/Texture.h
+++ b/source/globjects/include/globjects/Texture.h
@@ -48,6 +48,14 @@ public:
         DirectStateAccessARB
     };
 
+    enum class StorageMultisampleImplementation
+    {
+        Fallback,
+        Legacy,
+        DirectStateAccessEXT,
+        DirectStateAccessARB
+    };
+
     static void hintBindlessImplementation(BindlessImplementation impl);
     static void hintStorageImplementation(StorageImplementation impl);
 

--- a/source/globjects/source/Texture.cpp
+++ b/source/globjects/source/Texture.cpp
@@ -17,6 +17,7 @@
 #include "registry/ImplementationRegistry.h"
 #include "implementations/AbstractTextureImplementation.h"
 #include "implementations/AbstractTextureStorageImplementation.h"
+#include "implementations/AbstractTextureStorageMultisampleImplementation.h"
 
 
 using namespace gl;
@@ -34,6 +35,11 @@ const globjects::AbstractTextureImplementation & bindlessImplementation()
 const globjects::AbstractTextureStorageImplementation & storageImplementation()
 {
     return globjects::ImplementationRegistry::current().textureStorageImplementation();
+}
+
+const globjects::AbstractTextureStorageMultisampleImplementation & storageMultisampleImplementation()
+{
+    return globjects::ImplementationRegistry::current().textureStorageMultisampleImplementation();
 }
 
 
@@ -328,7 +334,7 @@ void Texture::storage3D(const GLsizei levels, const GLenum internalFormat, const
 
 void Texture::storage2DMultisample(GLsizei samples, GLenum internalFormat, GLsizei width, GLsizei height, GLboolean fixedSamplesLocations)
 {
-    storageImplementation().storage2DMultisample(this, samples, internalFormat, width, height, fixedSamplesLocations);
+    storageMultisampleImplementation().storage2DMultisample(this, samples, internalFormat, width, height, fixedSamplesLocations);
 }
 
 void Texture::storage2DMultisample(GLsizei samples, GLenum internalFormat, const glm::ivec2 & size, GLboolean fixedSamplesLocations)
@@ -338,7 +344,7 @@ void Texture::storage2DMultisample(GLsizei samples, GLenum internalFormat, const
 
 void Texture::storage3DMultisample(GLsizei samples, GLenum internalFormat, GLsizei width, GLsizei height, GLsizei depth, GLboolean fixedSamplesLocations)
 {
-    storageImplementation().storage3DMultisample(this, samples, internalFormat, width, height, depth, fixedSamplesLocations);
+    storageMultisampleImplementation().storage3DMultisample(this, samples, internalFormat, width, height, depth, fixedSamplesLocations);
 }
 
 void Texture::storage3DMultisample(GLsizei samples, GLenum internalFormat, const glm::ivec3 & size, GLboolean fixedSamplesLocations)

--- a/source/globjects/source/implementations/AbstractTextureStorageImplementation.h
+++ b/source/globjects/source/implementations/AbstractTextureStorageImplementation.h
@@ -24,9 +24,6 @@ public:
     virtual void storage2D(const Texture * texture, gl::GLsizei levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const  = 0;
     virtual void storage3D(const Texture * texture, gl::GLsizei levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth) const  = 0;
 
-    virtual void storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const = 0;
-    virtual void storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const = 0;
-
     virtual void cubeMapStorage(const Texture * texture, gl::GLint levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const = 0;
 };
 

--- a/source/globjects/source/implementations/AbstractTextureStorageMultisampleImplementation.cpp
+++ b/source/globjects/source/implementations/AbstractTextureStorageMultisampleImplementation.cpp
@@ -1,0 +1,54 @@
+
+#include "AbstractTextureStorageMultisampleImplementation.h"
+
+#include <glbinding/gl/enum.h>
+#include <glbinding/gl/extension.h>
+
+#include <globjects/globjects.h>
+
+#include "TextureStorageMultisampleImplementation_DirectStateAccessARB.h"
+#include "TextureStorageMultisampleImplementation_DirectStateAccessEXT.h"
+#include "TextureStorageMultisampleImplementation_Legacy.h"
+#include "TextureStorageMultisampleImplementation_Fallback.h"
+
+
+using namespace gl;
+
+
+namespace globjects
+{
+
+
+AbstractTextureStorageMultisampleImplementation::AbstractTextureStorageMultisampleImplementation()
+{
+}
+
+AbstractTextureStorageMultisampleImplementation::~AbstractTextureStorageMultisampleImplementation()
+{
+}
+
+AbstractTextureStorageMultisampleImplementation * AbstractTextureStorageMultisampleImplementation::get(const Texture::StorageMultisampleImplementation impl)
+{
+    if (!hasExtension(GLextension::GL_ARB_texture_storage_multisample))
+    {
+        return TextureStorageMultisampleImplementation_Fallback::instance();
+    }
+
+    if (impl == Texture::StorageMultisampleImplementation::DirectStateAccessARB
+     && hasExtension(GLextension::GL_ARB_direct_state_access))
+    {
+        return TextureStorageMultisampleImplementation_DirectStateAccessARB::instance();
+    }
+    else if (impl >= Texture::StorageMultisampleImplementation::DirectStateAccessEXT
+      && hasExtension(GLextension::GL_EXT_direct_state_access))
+    {
+        return TextureStorageMultisampleImplementation_DirectStateAccessEXT::instance();
+    }
+    else
+    {
+        return TextureStorageMultisampleImplementation_Legacy::instance();
+    }
+}
+
+
+} // namespace globjects

--- a/source/globjects/source/implementations/AbstractTextureStorageMultisampleImplementation.h
+++ b/source/globjects/source/implementations/AbstractTextureStorageMultisampleImplementation.h
@@ -1,0 +1,28 @@
+
+#pragma once
+
+
+#include <glbinding/gl/types.h>
+
+#include <globjects/Texture.h>
+
+
+namespace globjects
+{
+
+
+class AbstractTextureStorageMultisampleImplementation
+{
+public:
+    AbstractTextureStorageMultisampleImplementation();
+    virtual ~AbstractTextureStorageMultisampleImplementation();
+
+    static AbstractTextureStorageMultisampleImplementation * get(Texture::StorageMultisampleImplementation impl =
+        Texture::StorageMultisampleImplementation::DirectStateAccessARB);
+
+    virtual void storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const = 0;
+    virtual void storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const = 0;
+};
+
+
+} // namespace globjects

--- a/source/globjects/source/implementations/TextureStorageImplementation_DirectStateAccessARB.cpp
+++ b/source/globjects/source/implementations/TextureStorageImplementation_DirectStateAccessARB.cpp
@@ -41,17 +41,6 @@ void TextureStorageImplementation_DirectStateAccessARB::storage3D(const Texture 
     gl::glTextureStorage3D(texture->id(), levels, internalFormat, width, height, depth);
 }
 
-void TextureStorageImplementation_DirectStateAccessARB::storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const
-{
-    gl::glTextureStorage2DMultisample(texture->id(), samples, internalFormat, width, height, fixedSampleLocations);
-}
-
-void TextureStorageImplementation_DirectStateAccessARB::storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const
-{
-    gl::glTextureStorage3DMultisample(texture->id(), samples, internalFormat, width, height, depth, fixedSampleLocations);
-}
-
-
 void TextureStorageImplementation_DirectStateAccessARB::cubeMapStorage(const Texture * texture, gl::GLint levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const
 {
     storage2D(texture, levels, internalFormat, width, height);

--- a/source/globjects/source/implementations/TextureStorageImplementation_DirectStateAccessARB.h
+++ b/source/globjects/source/implementations/TextureStorageImplementation_DirectStateAccessARB.h
@@ -22,9 +22,6 @@ public:
     virtual void storage2D(const Texture * texture, gl::GLsizei levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const override;
     virtual void storage3D(const Texture * texture, gl::GLsizei levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth) const override;
 
-        virtual void storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const override;
-    virtual void storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const override;
-
     virtual void cubeMapStorage(const Texture * texture, gl::GLint levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const override;
 };
 

--- a/source/globjects/source/implementations/TextureStorageImplementation_DirectStateAccessEXT.cpp
+++ b/source/globjects/source/implementations/TextureStorageImplementation_DirectStateAccessEXT.cpp
@@ -38,16 +38,6 @@ void TextureStorageImplementation_DirectStateAccessEXT::storage3D(const Texture 
     gl::glTextureStorage3DEXT(texture->id(), texture->target(), levels, internalFormat, width, height, depth);
 }
 
-void TextureStorageImplementation_DirectStateAccessEXT::storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const
-{
-    gl::glTextureStorage2DMultisampleEXT(texture->id(), texture->target(), samples, internalFormat, width, height, fixedSampleLocations);
-}
-
-void TextureStorageImplementation_DirectStateAccessEXT::storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const
-{
-    gl::glTextureStorage3DMultisampleEXT(texture->id(), texture->target(), samples, internalFormat, width, height, depth, fixedSampleLocations);
-}
-
 void TextureStorageImplementation_DirectStateAccessEXT::cubeMapStorage(const Texture * texture, gl::GLint levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const
 {
     storage2D(texture, levels, internalFormat, width, height);

--- a/source/globjects/source/implementations/TextureStorageImplementation_DirectStateAccessEXT.h
+++ b/source/globjects/source/implementations/TextureStorageImplementation_DirectStateAccessEXT.h
@@ -22,9 +22,6 @@ public:
     virtual void storage2D(const Texture * texture, gl::GLsizei levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const override;
     virtual void storage3D(const Texture * texture, gl::GLsizei levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth) const override;
 
-    virtual void storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const override;
-    virtual void storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const override;
-
     virtual void cubeMapStorage(const Texture * texture, gl::GLint levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const override;
 };
 

--- a/source/globjects/source/implementations/TextureStorageImplementation_Fallback.cpp
+++ b/source/globjects/source/implementations/TextureStorageImplementation_Fallback.cpp
@@ -76,16 +76,6 @@ void TextureStorageImplementation_Fallback::storage3D(const Texture * texture, g
     }
 }
 
-void TextureStorageImplementation_Fallback::storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const
-{
-    bindlessImplementation().image2DMultisample(texture, samples, internalFormat, width, height, fixedSampleLocations);
-}
-
-void TextureStorageImplementation_Fallback::storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const
-{
-    bindlessImplementation().image3DMultisample(texture, samples, internalFormat, width, height, depth, fixedSampleLocations);
-}
-
 void TextureStorageImplementation_Fallback::cubeMapStorage(const Texture * texture, gl::GLint levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const
 {
     storage2D(texture, levels, internalFormat, width, height);

--- a/source/globjects/source/implementations/TextureStorageImplementation_Fallback.h
+++ b/source/globjects/source/implementations/TextureStorageImplementation_Fallback.h
@@ -22,9 +22,6 @@ public:
     virtual void storage2D(const Texture * texture, gl::GLsizei levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const override;
     virtual void storage3D(const Texture * texture, gl::GLsizei levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth) const override;
 
-    virtual void storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const override;
-    virtual void storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const override;
-
     virtual void cubeMapStorage(const Texture * texture, gl::GLint levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const override;
 };
 

--- a/source/globjects/source/implementations/TextureStorageImplementation_Legacy.cpp
+++ b/source/globjects/source/implementations/TextureStorageImplementation_Legacy.cpp
@@ -42,23 +42,6 @@ void TextureStorageImplementation_Legacy::storage3D(const Texture * texture, gl:
     gl::glTexStorage3D(texture->target(), levels, internalFormat, width, height, depth);
 }
 
-
-void TextureStorageImplementation_Legacy::storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const
-{
-    texture->bind();
-
-    gl::glTexStorage2DMultisample(texture->target(), samples, internalFormat, width, height, fixedSampleLocations);
-}
-
-
-void TextureStorageImplementation_Legacy::storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const
-{
-    texture->bind();
-
-    gl::glTexStorage3DMultisample(texture->target(), samples, internalFormat, width, height, depth, fixedSampleLocations);
-}
-
-
 void TextureStorageImplementation_Legacy::cubeMapStorage(const Texture * texture, gl::GLint levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const
 {
     storage2D(texture, levels, internalFormat, width, height);

--- a/source/globjects/source/implementations/TextureStorageImplementation_Legacy.h
+++ b/source/globjects/source/implementations/TextureStorageImplementation_Legacy.h
@@ -22,9 +22,6 @@ public:
     virtual void storage2D(const Texture * texture, gl::GLsizei levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const override;
     virtual void storage3D(const Texture * texture, gl::GLsizei levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth) const override;
 
-    virtual void storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const override;
-    virtual void storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const override;
-
     virtual void cubeMapStorage(const Texture * texture, gl::GLint levels, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height) const override;
 };
 

--- a/source/globjects/source/implementations/TextureStorageMultisampleImplementation_DirectStateAccessARB.cpp
+++ b/source/globjects/source/implementations/TextureStorageMultisampleImplementation_DirectStateAccessARB.cpp
@@ -1,0 +1,40 @@
+
+#include "TextureStorageMultisampleImplementation_DirectStateAccessARB.h"
+
+#include <glm/gtc/type_ptr.hpp>
+
+#include <glbinding/gl/enum.h>
+
+#include <globjects/globjects.h>
+
+#include "TextureImplementation_Legacy.h"
+#include "TextureImplementation_DirectStateAccessEXT.h"
+
+
+using namespace gl;
+
+
+namespace globjects
+{
+
+
+TextureStorageMultisampleImplementation_DirectStateAccessARB::TextureStorageMultisampleImplementation_DirectStateAccessARB()
+{
+}
+
+TextureStorageMultisampleImplementation_DirectStateAccessARB::~TextureStorageMultisampleImplementation_DirectStateAccessARB()
+{
+}
+
+void TextureStorageMultisampleImplementation_DirectStateAccessARB::storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const
+{
+    gl::glTextureStorage2DMultisample(texture->id(), samples, internalFormat, width, height, fixedSampleLocations);
+}
+
+void TextureStorageMultisampleImplementation_DirectStateAccessARB::storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const
+{
+    gl::glTextureStorage3DMultisample(texture->id(), samples, internalFormat, width, height, depth, fixedSampleLocations);
+}
+
+
+} // namespace globjects

--- a/source/globjects/source/implementations/TextureStorageMultisampleImplementation_DirectStateAccessARB.h
+++ b/source/globjects/source/implementations/TextureStorageMultisampleImplementation_DirectStateAccessARB.h
@@ -1,0 +1,26 @@
+
+#pragma once
+
+
+#include "../base/Singleton.h"
+
+#include "AbstractTextureStorageMultisampleImplementation.h"
+
+
+namespace globjects
+{
+
+
+class TextureStorageMultisampleImplementation_DirectStateAccessARB : public AbstractTextureStorageMultisampleImplementation
+    , public Singleton<TextureStorageMultisampleImplementation_DirectStateAccessARB>
+{
+public:
+    TextureStorageMultisampleImplementation_DirectStateAccessARB();
+    virtual ~TextureStorageMultisampleImplementation_DirectStateAccessARB();
+
+    virtual void storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const override;
+    virtual void storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const override;
+};
+
+
+} // namespace globjects

--- a/source/globjects/source/implementations/TextureStorageMultisampleImplementation_DirectStateAccessEXT.cpp
+++ b/source/globjects/source/implementations/TextureStorageMultisampleImplementation_DirectStateAccessEXT.cpp
@@ -1,0 +1,37 @@
+
+#include "TextureStorageMultisampleImplementation_DirectStateAccessEXT.h"
+
+#include <glm/gtc/type_ptr.hpp>
+
+#include <glbinding/gl/enum.h>
+
+#include <globjects/globjects.h>
+
+
+using namespace gl;
+
+
+namespace globjects
+{
+
+
+TextureStorageMultisampleImplementation_DirectStateAccessEXT::TextureStorageMultisampleImplementation_DirectStateAccessEXT()
+{
+}
+
+TextureStorageMultisampleImplementation_DirectStateAccessEXT::~TextureStorageMultisampleImplementation_DirectStateAccessEXT()
+{
+}
+
+void TextureStorageMultisampleImplementation_DirectStateAccessEXT::storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const
+{
+    gl::glTextureStorage2DMultisampleEXT(texture->id(), texture->target(), samples, internalFormat, width, height, fixedSampleLocations);
+}
+
+void TextureStorageMultisampleImplementation_DirectStateAccessEXT::storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const
+{
+    gl::glTextureStorage3DMultisampleEXT(texture->id(), texture->target(), samples, internalFormat, width, height, depth, fixedSampleLocations);
+}
+
+
+} // namespace globjects

--- a/source/globjects/source/implementations/TextureStorageMultisampleImplementation_DirectStateAccessEXT.h
+++ b/source/globjects/source/implementations/TextureStorageMultisampleImplementation_DirectStateAccessEXT.h
@@ -1,0 +1,26 @@
+
+#pragma once
+
+
+#include "../base/Singleton.h"
+
+#include "AbstractTextureStorageMultisampleImplementation.h"
+
+
+namespace globjects
+{
+
+
+class TextureStorageMultisampleImplementation_DirectStateAccessEXT : public AbstractTextureStorageMultisampleImplementation
+        , public Singleton<TextureStorageMultisampleImplementation_DirectStateAccessEXT>
+{
+public:
+    TextureStorageMultisampleImplementation_DirectStateAccessEXT();
+    virtual ~TextureStorageMultisampleImplementation_DirectStateAccessEXT();
+
+    virtual void storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const override;
+    virtual void storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const override;
+};
+
+
+} // namespace globjects

--- a/source/globjects/source/implementations/TextureStorageMultisampleImplementation_Fallback.cpp
+++ b/source/globjects/source/implementations/TextureStorageMultisampleImplementation_Fallback.cpp
@@ -1,0 +1,54 @@
+
+#include "TextureStorageMultisampleImplementation_Fallback.h"
+
+#include <cmath>
+
+#include <glm/gtc/type_ptr.hpp>
+
+#include <glbinding/gl/functions.h>
+#include <glbinding/gl/enum.h>
+
+#include <globjects/globjects.h>
+
+#include "../registry/ImplementationRegistry.h"
+
+#include "AbstractTextureImplementation.h"
+
+
+namespace
+{
+
+
+const globjects::AbstractTextureImplementation & bindlessImplementation()
+{
+    return globjects::ImplementationRegistry::current().textureBindlessImplementation();
+}
+
+
+} // namespace
+
+
+namespace globjects
+{
+
+
+TextureStorageMultisampleImplementation_Fallback::TextureStorageMultisampleImplementation_Fallback()
+{
+}
+
+TextureStorageMultisampleImplementation_Fallback::~TextureStorageMultisampleImplementation_Fallback()
+{
+}
+
+void TextureStorageMultisampleImplementation_Fallback::storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const
+{
+    bindlessImplementation().image2DMultisample(texture, samples, internalFormat, width, height, fixedSampleLocations);
+}
+
+void TextureStorageMultisampleImplementation_Fallback::storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const
+{
+    bindlessImplementation().image3DMultisample(texture, samples, internalFormat, width, height, depth, fixedSampleLocations);
+}
+
+
+} // namespace globjects

--- a/source/globjects/source/implementations/TextureStorageMultisampleImplementation_Fallback.h
+++ b/source/globjects/source/implementations/TextureStorageMultisampleImplementation_Fallback.h
@@ -1,0 +1,26 @@
+
+#pragma once
+
+
+#include "../base/Singleton.h"
+
+#include "AbstractTextureStorageMultisampleImplementation.h"
+
+
+namespace globjects
+{
+
+
+class TextureStorageMultisampleImplementation_Fallback : public AbstractTextureStorageMultisampleImplementation
+    , public Singleton<TextureStorageMultisampleImplementation_Fallback>
+{
+public:
+    TextureStorageMultisampleImplementation_Fallback();
+    virtual ~TextureStorageMultisampleImplementation_Fallback();
+
+    virtual void storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const override;
+    virtual void storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const override;
+};
+
+
+} // namespace globjects

--- a/source/globjects/source/implementations/TextureStorageMultisampleImplementation_Legacy.cpp
+++ b/source/globjects/source/implementations/TextureStorageMultisampleImplementation_Legacy.cpp
@@ -1,0 +1,39 @@
+
+#include "TextureStorageMultisampleImplementation_Legacy.h"
+
+#include <glm/gtc/type_ptr.hpp>
+
+#include <glbinding/gl/functions.h>
+#include <glbinding/gl/enum.h>
+
+#include <globjects/globjects.h>
+
+
+namespace globjects
+{
+
+
+TextureStorageMultisampleImplementation_Legacy::TextureStorageMultisampleImplementation_Legacy()
+{
+}
+
+TextureStorageMultisampleImplementation_Legacy::~TextureStorageMultisampleImplementation_Legacy()
+{
+}
+
+void TextureStorageMultisampleImplementation_Legacy::storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const
+{
+    texture->bind();
+
+    gl::glTexStorage2DMultisample(texture->target(), samples, internalFormat, width, height, fixedSampleLocations);
+}
+
+void TextureStorageMultisampleImplementation_Legacy::storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const
+{
+    texture->bind();
+
+    gl::glTexStorage3DMultisample(texture->target(), samples, internalFormat, width, height, depth, fixedSampleLocations);
+}
+
+
+} // namespace globjects

--- a/source/globjects/source/implementations/TextureStorageMultisampleImplementation_Legacy.h
+++ b/source/globjects/source/implementations/TextureStorageMultisampleImplementation_Legacy.h
@@ -1,0 +1,26 @@
+
+#pragma once
+
+
+#include "../base/Singleton.h"
+
+#include "AbstractTextureStorageMultisampleImplementation.h"
+
+
+namespace globjects
+{
+
+
+class TextureStorageMultisampleImplementation_Legacy : public AbstractTextureStorageMultisampleImplementation
+    , public Singleton<TextureStorageMultisampleImplementation_Legacy>
+{
+public:
+    TextureStorageMultisampleImplementation_Legacy();
+    virtual ~TextureStorageMultisampleImplementation_Legacy();
+
+    virtual void storage2DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLboolean fixedSampleLocations) const override;
+    virtual void storage3DMultisample(const Texture * texture, gl::GLsizei samples, gl::GLenum internalFormat, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth, gl::GLboolean fixedSampleLocations) const override;
+};
+
+
+} // namespace globjects

--- a/source/globjects/source/registry/ImplementationRegistry.cpp
+++ b/source/globjects/source/registry/ImplementationRegistry.cpp
@@ -12,6 +12,7 @@
 #include "../implementations/AbstractObjectNameImplementation.h"
 #include "../implementations/AbstractTextureImplementation.h"
 #include "../implementations/AbstractTextureStorageImplementation.h"
+#include "../implementations/AbstractTextureStorageMultisampleImplementation.h"
 #include "../implementations/AbstractVertexAttributeBindingImplementation.h"
 
 
@@ -29,6 +30,7 @@ ImplementationRegistry::ImplementationRegistry()
 , m_objectNameImplementation(nullptr)
 , m_textureBindlessImplementation(nullptr)
 , m_textureStorageImplementation(nullptr)
+, m_textureStorageMultisampleImplementation(nullptr)
 , m_attributeImplementation(nullptr)
 {
 }
@@ -45,6 +47,7 @@ ImplementationRegistry::~ImplementationRegistry()
     delete m_attributeImplementation;
     delete m_textureBindlessImplementation;
     delete m_textureStorageImplementation;
+    delete m_textureStorageMultisampleImplementation;
 }
 
 ImplementationRegistry & ImplementationRegistry::current()
@@ -64,6 +67,7 @@ void ImplementationRegistry::initialize()
     m_attributeImplementation = AbstractVertexAttributeBindingImplementation::get();
     m_textureBindlessImplementation = AbstractTextureImplementation::get();
     m_textureStorageImplementation = AbstractTextureStorageImplementation::get();
+    m_textureStorageMultisampleImplementation = AbstractTextureStorageMultisampleImplementation::get();
 }
 
 void ImplementationRegistry::initialize(const AbstractUniform::BindlessImplementation impl)
@@ -114,6 +118,11 @@ void ImplementationRegistry::initialize(Texture::BindlessImplementation impl)
 void ImplementationRegistry::initialize(Texture::StorageImplementation impl)
 {
     m_textureStorageImplementation = AbstractTextureStorageImplementation::get(impl);
+}
+
+void ImplementationRegistry::initialize(Texture::StorageMultisampleImplementation impl)
+{
+    m_textureStorageMultisampleImplementation = AbstractTextureStorageMultisampleImplementation::get(impl);
 }
 
 AbstractUniformImplementation & ImplementationRegistry::uniformImplementation()
@@ -194,6 +203,14 @@ AbstractTextureStorageImplementation & ImplementationRegistry::textureStorageImp
         m_textureStorageImplementation = AbstractTextureStorageImplementation::get();
 
     return *m_textureStorageImplementation;
+}
+
+AbstractTextureStorageMultisampleImplementation & ImplementationRegistry::textureStorageMultisampleImplementation()
+{
+    if (!m_textureStorageMultisampleImplementation)
+        m_textureStorageMultisampleImplementation = AbstractTextureStorageMultisampleImplementation::get();
+
+    return *m_textureStorageMultisampleImplementation;
 }
 
 

--- a/source/globjects/source/registry/ImplementationRegistry.h
+++ b/source/globjects/source/registry/ImplementationRegistry.h
@@ -26,6 +26,7 @@ class AbstractObjectNameImplementation;
 class AbstractVertexAttributeBindingImplementation;
 class AbstractTextureImplementation;
 class AbstractTextureStorageImplementation;
+class AbstractTextureStorageMultisampleImplementation;
 
 
 class ImplementationRegistry
@@ -46,6 +47,7 @@ public:
     void initialize(VertexArray::AttributeImplementation impl);
     void initialize(Texture::BindlessImplementation impl);
     void initialize(Texture::StorageImplementation impl);
+    void initialize(Texture::StorageMultisampleImplementation impl);
 
     static ImplementationRegistry & current();
 
@@ -59,6 +61,7 @@ public:
     AbstractVertexAttributeBindingImplementation & attributeImplementation();
     AbstractTextureImplementation & textureBindlessImplementation();
     AbstractTextureStorageImplementation & textureStorageImplementation();
+    AbstractTextureStorageMultisampleImplementation & textureStorageMultisampleImplementation();
 
 
 protected:
@@ -71,6 +74,7 @@ protected:
     AbstractObjectNameImplementation * m_objectNameImplementation;
     AbstractTextureImplementation * m_textureBindlessImplementation;
     AbstractTextureStorageImplementation * m_textureStorageImplementation;
+    AbstractTextureStorageMultisampleImplementation * m_textureStorageMultisampleImplementation;
     AbstractVertexAttributeBindingImplementation * m_attributeImplementation;
 };
 


### PR DESCRIPTION
... because these functions come from a separate extension: https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_texture_storage_multisample.txt that is not available e.g., on mac.