### PR TITLE
Add init overloads with addional glbinding::ContextHandle parameter

### DIFF
--- a/source/globjects/include/globjects/globjects.h
+++ b/source/globjects/include/globjects/globjects.h
@@ -38,7 +38,9 @@ namespace globjects
 
 
 GLOBJECTS_API void init(glbinding::GetProcAddress functionPointerResolver);
+GLOBJECTS_API void init(glbinding::ContextHandle contextHandle, glbinding::GetProcAddress functionPointerResolver);
 GLOBJECTS_API void init(glbinding::GetProcAddress functionPointerResolver, glbinding::ContextHandle sharedContextId);
+GLOBJECTS_API void init(glbinding::ContextHandle contextHandle, glbinding::GetProcAddress functionPointerResolver, glbinding::ContextHandle sharedContextId);
 
 /** \brief calls detach on every registered object
     
@@ -51,10 +53,18 @@ template <typename T, typename... Args>
 void init(glbinding::GetProcAddress functionPointerResolver, T strategy, Args... args);
 
 template <typename T, typename... Args>
+void init(glbinding::ContextHandle contextHandle, glbinding::GetProcAddress functionPointerResolver, T strategy, Args... args);
+
+template <typename T, typename... Args>
 void init(glbinding::GetProcAddress functionPointerResolver, glbinding::ContextHandle sharedContextId, T strategy, Args... args);
+
+template <typename T, typename... Args>
+void init(glbinding::ContextHandle contextHandle, glbinding::GetProcAddress functionPointerResolver, glbinding::ContextHandle sharedContextId, T strategy, Args... args);
 
 GLOBJECTS_API void registerCurrentContext(glbinding::GetProcAddress functionPointerResolver);
 GLOBJECTS_API void registerCurrentContext(glbinding::GetProcAddress functionPointerResolver, glbinding::ContextHandle sharedContextId);
+GLOBJECTS_API void registerContext(glbinding::ContextHandle contextHandle, glbinding::GetProcAddress functionPointerResolver);
+GLOBJECTS_API void registerContext(glbinding::ContextHandle contextHandle, glbinding::GetProcAddress functionPointerResolver, glbinding::ContextHandle sharedContextId);
 GLOBJECTS_API void setContext(glbinding::ContextHandle contextId);
 GLOBJECTS_API void setCurrentContext();
 

--- a/source/globjects/include/globjects/globjects.inl
+++ b/source/globjects/include/globjects/globjects.inl
@@ -61,18 +61,30 @@ std::array<gl::GLboolean, Count> getBooleans(const gl::GLenum pname)
     return values;
 }
 
-template <typename T, typename... Args>
+template <typename T, typename ... Args>
 void init(glbinding::GetProcAddress functionPointerResolver, T strategy, Args... args)
 {
-    init(functionPointerResolver, args...);
+    init(0, functionPointerResolver, strategy, args...);
+}
+
+template <typename T, typename... Args>
+void init(glbinding::ContextHandle contextHandle, glbinding::GetProcAddress functionPointerResolver, T strategy, Args... args)
+{
+    init(contextHandle, functionPointerResolver, args...);
 
     initializeStrategy(strategy);
 }
 
-template <typename T, typename... Args>
-void init(glbinding::GetProcAddress functionPointerResolver, const glbinding::ContextHandle sharedContextId, T strategy, Args... args)
+template <typename T, typename ... Args>
+void init(glbinding::GetProcAddress functionPointerResolver, glbinding::ContextHandle sharedContextId, T strategy, Args... args)
 {
-    init(functionPointerResolver, sharedContextId, args...);
+    init(0, functionPointerResolver, sharedContextId, strategy, args...);
+}
+
+template <typename T, typename... Args>
+void init(glbinding::ContextHandle contextHandle, glbinding::GetProcAddress functionPointerResolver, const glbinding::ContextHandle sharedContextId, T strategy, Args... args)
+{
+    init(contextHandle, functionPointerResolver, sharedContextId, args...);
 
     initializeStrategy(strategy);
 }

--- a/source/globjects/source/globjects.cpp
+++ b/source/globjects/source/globjects.cpp
@@ -97,21 +97,10 @@ namespace globjects
 
 void init(glbinding::GetProcAddress functionPointerResolver)
 {
-    {
-        std::lock_guard<std::mutex> lock(g_mutex);
-
-        if (!g_globjectsIsInitialized)
-        {
-            initializeCallbacks();
-
-            g_globjectsIsInitialized = true;
-        }
-    }
-
-    registerCurrentContext(functionPointerResolver);
+    init(0, functionPointerResolver);
 }
 
-void init(glbinding::GetProcAddress functionPointerResolver, const glbinding::ContextHandle sharedContextId)
+void init(glbinding::ContextHandle contextHandle, glbinding::GetProcAddress functionPointerResolver)
 {
     {
         std::lock_guard<std::mutex> lock(g_mutex);
@@ -124,7 +113,28 @@ void init(glbinding::GetProcAddress functionPointerResolver, const glbinding::Co
         }
     }
 
-    registerCurrentContext(functionPointerResolver, sharedContextId);
+    registerContext(contextHandle, functionPointerResolver);
+}
+
+void init(glbinding::GetProcAddress functionPointerResolver, const glbinding::ContextHandle sharedContextId)
+{
+    init(0, functionPointerResolver, sharedContextId);
+}
+
+void init(glbinding::ContextHandle contextHandle, glbinding::GetProcAddress functionPointerResolver, glbinding::ContextHandle sharedContextId)
+{
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+
+        if (!g_globjectsIsInitialized)
+        {
+            initializeCallbacks();
+
+            g_globjectsIsInitialized = true;
+        }
+    }
+
+    registerContext(contextHandle, functionPointerResolver, sharedContextId);
 }
 
 void detachAllObjects()
@@ -135,14 +145,24 @@ void detachAllObjects()
 
 void registerCurrentContext(glbinding::GetProcAddress functionPointerResolver)
 {
-    glbinding::Binding::initialize(functionPointerResolver);
-    Registry::registerContext(0);
+    registerContext(0, functionPointerResolver);
 }
 
 void registerCurrentContext(glbinding::GetProcAddress functionPointerResolver, const glbinding::ContextHandle sharedContextId)
 {
+    registerContext(0, functionPointerResolver, sharedContextId);
+}
+
+void registerContext(glbinding::ContextHandle contextHandle, glbinding::GetProcAddress functionPointerResolver)
+{
     glbinding::Binding::initialize(functionPointerResolver);
-    Registry::registerContext(0, sharedContextId);
+    Registry::registerContext(contextHandle);
+}
+
+void registerContext(glbinding::ContextHandle contextHandle, glbinding::GetProcAddress functionPointerResolver, glbinding::ContextHandle sharedContextId)
+{
+    glbinding::Binding::initialize(functionPointerResolver);
+    Registry::registerContext(contextHandle, sharedContextId);
 }
 
 void setContext(const glbinding::ContextHandle contextId)


### PR DESCRIPTION
Related to cginternals/glbinding#265. This lets the user explicitly set a context handle when initializing globjects and thus glbinding to avoid the conflict for handle 0. This does not solve the underlying glbinding issue though.