### PR TITLE
Remove assert in drawArraysIndirect ...

### DIFF
--- a/source/globjects/source/VertexArray.cpp
+++ b/source/globjects/source/VertexArray.cpp
@@ -161,6 +161,8 @@ void VertexArray::drawArraysInstancedBaseInstance(const GLenum mode, const GLint
 
 void VertexArray::drawArraysIndirect(const GLenum mode, const void* indirect) const
 {
+    // Don't assert a non-null indirect pointer as it may be a zero offset into the indirection buffer in GPU memory
+    
     bind();
     glDrawArraysIndirect(mode, indirect);
 }

--- a/source/globjects/source/VertexArray.cpp
+++ b/source/globjects/source/VertexArray.cpp
@@ -161,8 +161,6 @@ void VertexArray::drawArraysInstancedBaseInstance(const GLenum mode, const GLint
 
 void VertexArray::drawArraysIndirect(const GLenum mode, const void* indirect) const
 {
-    assert(indirect != nullptr);
-
     bind();
     glDrawArraysIndirect(mode, indirect);
 }


### PR DESCRIPTION
… which prohibits drawing from bound indirect buffer at offset 0 in debug mode.
This change is consistent with the remaining wrapped indirect draw calls.