### PR TITLE
Resolve ambiguous function call with C++17

### DIFF
--- a/source/globjects/include/globjects/base/FunctionCall.inl
+++ b/source/globjects/include/globjects/base/FunctionCall.inl
@@ -7,7 +7,7 @@
 #include <utility>
 
 
-namespace 
+namespace
 {
 
 
@@ -92,7 +92,7 @@ FunctionCall<Arguments...>::FunctionCall()
 template <typename... Arguments>
 void FunctionCall<Arguments...>::operator()()
 {
-    apply(m_function, m_arguments);
+    ::apply(m_function, m_arguments);
 }
 
 template <typename... Arguments>

--- a/source/globjects/include/globjects/base/FunctionCall.inl
+++ b/source/globjects/include/globjects/base/FunctionCall.inl
@@ -7,7 +7,9 @@
 #include <utility>
 
 
-namespace
+namespace globjects
+{
+namespace detail
 {
 
 
@@ -69,11 +71,7 @@ inline auto apply(F && f, T && t)
 }
 
 
-} // namespace
-
-
-namespace globjects
-{
+} // namespace detail
 
 
 template <typename... Arguments>
@@ -92,7 +90,7 @@ FunctionCall<Arguments...>::FunctionCall()
 template <typename... Arguments>
 void FunctionCall<Arguments...>::operator()()
 {
-    ::apply(m_function, m_arguments);
+    detail::apply(m_function, m_arguments);
 }
 
 template <typename... Arguments>


### PR DESCRIPTION
C++17 has `std::apply` which is found via ADL and conflicts with the custom `apply` function.